### PR TITLE
allow disabling/moving Notes quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/settings/questselection/QuestVisibility.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/settings/questselection/QuestVisibility.kt
@@ -4,5 +4,5 @@ import de.westnordost.streetcomplete.data.osmnotes.notequests.OsmNoteQuestType
 import de.westnordost.streetcomplete.data.quest.QuestType
 
 data class QuestVisibility(val questType: QuestType<*>, var visible: Boolean) {
-    val isInteractionEnabled get() = questType !is OsmNoteQuestType
+    val isInteractionEnabled = true
 }


### PR DESCRIPTION
in upstream SC it is not possible to disable or move `Notes quest`, but it is useful to be able to disable it, especially for testing (when one wants to see only one quest to debug it, and not have screen littered also with Notes)