### PR TITLE
Fix #383: Allow insecure connections to Osmose

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,7 +38,8 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme"
-        android:supportsRtl="true">
+        android:supportsRtl="true"
+        android:usesCleartextTraffic="true">
         <meta-data android:name="com.google.ar.core" android:value="optional" />
         <activity
             android:windowSoftInputMode="adjustResize"


### PR DESCRIPTION
* The Osmose server is only available via http (it redirects https to http)
* We still leave the https:// URLs in, so in case one day they support https, we can still use it