### PR TITLE
ContactWebsite-Quest: switch from http to https

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/contact/AddContactWebsiteForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/contact/AddContactWebsiteForm.kt
@@ -43,7 +43,7 @@ class AddContactWebsiteForm : AbstractOsmQuestForm<String>() {
     override fun isFormComplete() = contact.isNotEmpty() && contact != prefill && contact.contains('.')
 
     companion object {
-        private var prefill = "http://"
+        private var prefill = "https://"
     }
 
 }


### PR DESCRIPTION
Since 2022 at the latest, it has been standard to use HTTPS in all browsers. Therefore, `https` instead of `http` should be suggested in the protocol proposal in SCEE.