### PR TITLE
implement sdf icons

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapIcons.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapIcons.kt
@@ -15,6 +15,12 @@ import de.westnordost.streetcomplete.util.ktx.createBitmap
 import de.westnordost.streetcomplete.util.ktx.dpToPx
 import de.westnordost.streetcomplete.util.ktx.toSdf
 import de.westnordost.streetcomplete.view.presetIconIndex
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
 import kotlin.math.ceil
 
 class MapIcons(
@@ -71,14 +77,18 @@ class MapIcons(
     }
 
     private fun createPresetBitmaps(): HashMap<String, Bitmap> {
-        val result = HashMap<String, Bitmap>(presetIconIndex.values.size)
-        for (presetIconResId in presetIconIndex.values) {
-            val name = context.resources.getResourceEntryName(presetIconResId)
-            val bitmap = context.getDrawable(presetIconResId)!!.createBitmap().toSdf(
-                radius = ceil(context.resources.dpToPx(2.5)).toInt()
-            )
-            result[name] = bitmap
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val deferredIcons = presetIconIndex.values.map { presetIconResId ->
+            scope.async {
+                val name = context.resources.getResourceEntryName(presetIconResId)
+                val bitmap = context.getDrawable(presetIconResId)!!.createBitmap().toSdf(
+                    radius = ceil(context.resources.dpToPx(2.5)).toInt()
+                )
+                name to bitmap
+            }
         }
+        val result = HashMap<String, Bitmap>(presetIconIndex.values.size)
+        runBlocking { deferredIcons.awaitAll().associateTo(result) { it } }
         return result
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapIcons.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapIcons.kt
@@ -13,6 +13,7 @@ import de.westnordost.streetcomplete.osm.building.iconResId
 import de.westnordost.streetcomplete.osm.building.iconResName
 import de.westnordost.streetcomplete.util.ktx.createBitmap
 import de.westnordost.streetcomplete.util.ktx.dpToPx
+import de.westnordost.streetcomplete.util.ktx.toSdf
 import de.westnordost.streetcomplete.view.presetIconIndex
 import kotlin.math.ceil
 
@@ -73,7 +74,9 @@ class MapIcons(
         val result = HashMap<String, Bitmap>(presetIconIndex.values.size)
         for (presetIconResId in presetIconIndex.values) {
             val name = context.resources.getResourceEntryName(presetIconResId)
-            val bitmap = context.getDrawable(presetIconResId)!!.createBitmap()
+            val bitmap = context.getDrawable(presetIconResId)!!.createBitmap().toSdf(
+                radius = ceil(context.resources.dpToPx(2.5)).toInt()
+            )
             result[name] = bitmap
         }
         return result

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/StyleableOverlayMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/StyleableOverlayMapComponent.kt
@@ -174,13 +174,11 @@ class StyleableOverlayMapComponent(private val context: Context, private val map
                 textSize(16 * context.resources.configuration.fontScale),
                 textColor(if (isNightMode) "#ccf" else "#124"),
                 textHaloColor(if (isNightMode) "#2e2e48" else "#fff"),
-                textHaloWidth(2.5f),
+                textHaloWidth(2.0f),
                 iconColor(if (isNightMode) "#ccf" else "#124"),
-                // as workaround for https://github.com/maplibre/maplibre-native/issues/2175
-                // - ugly SDF icons especially with halo - don't show the icon halo for now
-                //iconHaloColor(if (isNightMode) "#2e2e48" else "#fff"),
-                //iconHaloWidth(2.5f),
-                //iconHaloBlur(2f),
+                iconHaloColor(if (isNightMode) "#2e2e48" else "#fff"),
+                // multiply by screen density to workaround https://github.com/maplibre/maplibre-native/issues/2281
+                iconHaloWidth(2.0f * context.resources.displayMetrics.density),
                 textOptional(true),
                 iconAllowOverlap(step(zoom(), literal(false), stop(19, true))),
                 textAllowOverlap(step(zoom(), literal(false), stop(21, true))),

--- a/app/src/main/java/de/westnordost/streetcomplete/util/ktx/Bitmap.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/ktx/Bitmap.kt
@@ -2,8 +2,20 @@ package de.westnordost.streetcomplete.util.ktx
 
 import android.graphics.Bitmap
 import android.graphics.Matrix
+import de.westnordost.streetcomplete.util.sdf.convertToSdf
+import kotlin.math.ceil
 
 fun Bitmap.flipHorizontally(): Bitmap {
     val matrix = Matrix().apply { postScale(-1f, 1f, width / 2f, width / 2f) }
     return Bitmap.createBitmap(this, 0, 0, width, height, matrix, true)
+}
+
+fun Bitmap.toSdf(radius: Int = 9, cutoff: Double = 0.25): Bitmap {
+    val buffer = ceil(radius * (1.0 - cutoff)).toInt()
+    val w = width + 2 * buffer
+    val h = height + 2 * buffer
+    val pixels = IntArray(w * h)
+    getPixels(pixels, w * buffer + buffer, w, 0, 0, width, height)
+    convertToSdf(pixels, w, radius)
+    return Bitmap.createBitmap(pixels, w, pixels.size / w, Bitmap.Config.ARGB_8888)
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/util/sdf/Sdf.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/sdf/Sdf.kt
@@ -1,0 +1,91 @@
+package de.westnordost.streetcomplete.util.sdf
+
+import kotlin.math.max
+import kotlin.math.round
+import kotlin.math.sqrt
+
+// initially copied from https://github.com/mapbox/tiny-sdf/blob/main/index.js and then made to
+// work with a simple ARGB IntArray and simplified
+
+private const val INF = 1e20
+
+fun convertToSdf(
+    bitmap: IntArray,
+    width: Int,
+    radius: Int = 9,
+    cutoff: Double = 0.25
+) {
+    val height = bitmap.size / width
+
+    val gridOuter = DoubleArray(bitmap.size) { i ->
+        when (val a = bitmap[i].ushr(24)) {
+            0 -> INF
+            255 -> 0.0
+            else -> {
+                val d = 0.5f - (a.toDouble() / 255.0)
+                if (d > 0) d * d else 0.0
+            }
+        }
+    }
+
+    val gridInner = DoubleArray(bitmap.size) { i ->
+        when (val a = bitmap[i].ushr(24)) {
+            0 -> 0.0
+            255 -> INF
+            else -> {
+                val d = 0.5f - (a.toDouble() / 255.0)
+                if (d < 0) d * d else 0.0
+            }
+        }
+    }
+    val size = max(width, height)
+    val f = DoubleArray(size)
+    val z = DoubleArray(size + 1)
+    val v = IntArray(size)
+
+    edt(gridOuter, width, height, f, v, z)
+    edt(gridInner, width, height, f, v, z)
+
+    for (i in bitmap.indices) {
+        val dist = sqrt(gridOuter[i]) - sqrt(gridInner[i])
+        bitmap[i] = round(255 - 255 * (dist / radius + cutoff)).toInt().coerceIn(0, 255).shl(24)
+    }
+}
+
+// 2D Euclidean squared distance transform by Felzenszwalb & Huttenlocher https://cs.brown.edu/~pff/papers/dt-final.pdf
+private fun edt(data: DoubleArray, width: Int, height: Int, f: DoubleArray, v: IntArray, z: DoubleArray) {
+    for (x in 0 ..< width)  edt1d(data, x, width, height, f, v, z)
+    for (y in 0 ..< height) edt1d(data, y * width, 1, width, f, v, z)
+}
+
+// 1D squared distance transform
+private fun edt1d(grid: DoubleArray, offset: Int, stride: Int, length: Int, f: DoubleArray, v: IntArray, z: DoubleArray) {
+    v[0] = 0
+    z[0] = -INF
+    z[1] = INF
+    f[0] = grid[offset]
+
+    var k = 0
+    for (q in 1 ..< length) {
+        f[q] = grid[offset + q * stride]
+        val q2 = q * q
+        var s: Double
+        do {
+            val r = v[k]
+            s = (f[q] - f[r] + q2 - r * r) / (q - r) / 2.0
+        } while (s <= z[k] && --k > -1)
+
+        k++
+        v[k] = q
+        z[k] = s
+        z[k + 1] = INF
+    }
+
+    k = 0
+    for (q in 0 ..< length) {
+        while (z[k + 1] < q) k++
+        val r = v[k]
+        val qr = q - r
+        grid[offset + q * stride] = f[r] + qr * qr
+    }
+}


### PR DESCRIPTION
I implemented SDF icons. Basically, you have to blur a black-and-white graphic to achieve an SDF.

But should we use this, after all?

**Pro:**
- same look as now, for the shop and things overlay. However, the building icons continue to not have a halo because the halo only works for SDFs. Arguably, since there are no black elements on the map, the SDF icons don't actually _need_ a halo (for night mode, the icons are white).
  For the buildings, a halo would be nice, but neither necessary (imo) not possible (with maplibre halos at least)
- (is it faster than not using SDF icons?)

**Contra:**
- startup takes 0.5s longer (on my device) because blurring the 730+ preset icons takes that long
- +100 lines of code
