### PR TITLE
Add clustering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Migrated from the map renderer tangram-es to [MapLibre](https://maplibre.org/). 
 
 Display-wise, nothing much *should* change, the map will just look and behave a little different.
 
-Issues solved by the migration are #5601, #5241, #5216, #5161, #5146, #5137, #5048, #5027, #5006, #4844, #4556, #4554, #4550, #4542, #4522, #4277, #4259, #3417, #3397, #3346, #3275, #3022, #2711, #2703, #2612, #2571, #2187, #1713, #1684, #1019, #807, #318, [mapstyle#119](https://github.com/streetcomplete/streetcomplete-mapstyle/issues/119), [mapstyle#56](https://github.com/streetcomplete/streetcomplete-mapstyle/issues/56)... maybe more. Thanks to @riQQ for this list.
+Issues solved by the migration are #5601, #5241, #5216, #5161, #5146, #5137, #5048, #5027, #5006, #4844, #4556, #4554, #4550, #4542, #4522, #4277, #4259, #4026, #3417, #3397, #3346, #3275, #3022, #2878, #2711, #2703, #2612, #2571, #2373, #2359, #2358, #2187, #1713, #1684, #1264, #1019, #869, #807, #318, #179, [mapstyle#119](https://github.com/streetcomplete/streetcomplete-mapstyle/issues/119), [mapstyle#56](https://github.com/streetcomplete/streetcomplete-mapstyle/issues/56)... maybe more. Thanks to @riQQ for this list.
 
 ## v57.2
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
@@ -325,11 +325,13 @@ class MainMapFragment : MapFragment(), ShowsGeometryMarkers {
 
         if (jsonObject != null) {
             if (jsonObject.has("point_count")) {
+                // zoom-in to cluster
                 val bbox = pinsMapComponent?.getBboxForCluster(feature)
                 val target = bbox?.let { map?.getEnclosingCamera(it, Insets.NONE) }
                 target?.let { updateCameraPosition(300) {
                     this.position = it.position
-                    this.zoom = (it.zoom - 0.2).coerceAtMost(19.0) // don't zoom in fully
+                    // don't zoom in fully: leave some space to show the full pins, and limit max zoom
+                    this.zoom = (it.zoom - 0.25).coerceAtMost(19.0)
                 } }
                 return true
             }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
@@ -20,6 +20,7 @@ import de.westnordost.streetcomplete.data.location.RecentLocationStore
 import de.westnordost.streetcomplete.data.map.MapStateStore
 import de.westnordost.streetcomplete.data.osm.edits.MapDataWithEditsSource
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
+import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementKey
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osmtracks.Trackpoint
@@ -37,6 +38,7 @@ import de.westnordost.streetcomplete.screens.main.map.components.SelectedPinsMap
 import de.westnordost.streetcomplete.screens.main.map.components.StyleableOverlayMapComponent
 import de.westnordost.streetcomplete.screens.main.map.components.TracksMapComponent
 import de.westnordost.streetcomplete.screens.main.map.maplibre.camera
+import de.westnordost.streetcomplete.screens.main.map.maplibre.getEnclosingCamera
 import de.westnordost.streetcomplete.screens.main.map.maplibre.toLatLon
 import de.westnordost.streetcomplete.util.ktx.currentDisplay
 import de.westnordost.streetcomplete.util.ktx.dpToPx
@@ -324,12 +326,20 @@ class MainMapFragment : MapFragment(), ShowsGeometryMarkers {
 
         if (jsonObject != null) {
             if (jsonObject.has("point_count")) {
-                updateCameraPosition(300) {
+                val bbox = pinsMapComponent?.getBboxForCluster(feature)
+                val geo = bbox?.let { ElementPolylinesGeometry(listOf(listOf(it.max, it.min)), it.min) } // incorrect and cheap
+
+                val target = geo?.let { map?.getEnclosingCamera(it, Insets.NONE) }
+                target?.let { updateCameraPosition(300) {
+                    this.position = it.position
+                    this.zoom = (it.zoom - 0.2).coerceAtMost(19.0) // don't zoom in fully
+                } }
+/*                updateCameraPosition(300) {
                     this.position = position.toLatLon()
                     // this zooms so that the cluster splits into single elements or other clusters
                     // getClusterChildren() and calculating bbox would be even better
                     zoom = pinsMapComponent?.getClusterExpansionZoom(feature)?.coerceAtMost(19)?.toDouble()
-                }
+                }*/
                 return true
             }
             when (pinMode) {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
@@ -20,7 +20,6 @@ import de.westnordost.streetcomplete.data.location.RecentLocationStore
 import de.westnordost.streetcomplete.data.map.MapStateStore
 import de.westnordost.streetcomplete.data.osm.edits.MapDataWithEditsSource
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
-import de.westnordost.streetcomplete.data.osm.geometry.ElementPolylinesGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.ElementKey
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.osmtracks.Trackpoint
@@ -327,19 +326,11 @@ class MainMapFragment : MapFragment(), ShowsGeometryMarkers {
         if (jsonObject != null) {
             if (jsonObject.has("point_count")) {
                 val bbox = pinsMapComponent?.getBboxForCluster(feature)
-                val geo = bbox?.let { ElementPolylinesGeometry(listOf(listOf(it.max, it.min)), it.min) } // incorrect and cheap
-
-                val target = geo?.let { map?.getEnclosingCamera(it, Insets.NONE) }
+                val target = bbox?.let { map?.getEnclosingCamera(it, Insets.NONE) }
                 target?.let { updateCameraPosition(300) {
                     this.position = it.position
                     this.zoom = (it.zoom - 0.2).coerceAtMost(19.0) // don't zoom in fully
                 } }
-/*                updateCameraPosition(300) {
-                    this.position = position.toLatLon()
-                    // this zooms so that the cluster splits into single elements or other clusters
-                    // getClusterChildren() and calculating bbox would be even better
-                    zoom = pinsMapComponent?.getClusterExpansionZoom(feature)?.coerceAtMost(19)?.toDouble()
-                }*/
                 return true
             }
             when (pinMode) {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
@@ -318,12 +318,20 @@ class MainMapFragment : MapFragment(), ShowsGeometryMarkers {
         // only query specific layer(s) - leaving layerIds empty would query all layers
         // result is already sorted by visual render order, descending
         val jsonObject = map?.queryRenderedFeatures(searchArea,
-            "pins-layer", "overlay-symbols", "overlay-lines", "overlay-lines-dashed", "overlay-fills"
+            "pins-layer", "pin-dot-layer", "overlay-symbols", "overlay-lines", "overlay-lines-dashed", "overlay-fills"
         )?.firstOrNull()?.properties()
 
         if (jsonObject != null) {
             when (pinMode) {
                 PinMode.QUESTS -> {
+                    if (jsonObject.has("point_count")) {
+                        // todo:
+                        //  move and zoom so all pins in cluster are on screen
+                        //  consider there should be some padding
+                        //  and a certain max zoom
+                        updateCameraPosition(300) { zoomBy = +1.0 }
+                        return true
+                    }
                     val properties = pinsMapComponent?.getProperties(jsonObject)
                     val questKey = properties?.let { questPinsManager?.getQuestKey(it) }
                     if (questKey != null) {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
@@ -204,7 +204,7 @@ class MainMapFragment : MapFragment(), ShowsGeometryMarkers {
         tracksMapComponent = TracksMapComponent(context, style, map)
         viewLifecycleOwner.lifecycle.addObserver(tracksMapComponent!!)
 
-        pinsMapComponent = PinsMapComponent(map)
+        pinsMapComponent = PinsMapComponent(context.contentResolver, map)
         geometryMapComponent = FocusGeometryMapComponent(context.contentResolver, map)
         viewLifecycleOwner.lifecycle.addObserver(geometryMapComponent!!)
 
@@ -321,14 +321,7 @@ class MainMapFragment : MapFragment(), ShowsGeometryMarkers {
 
         if (jsonObject != null) {
             if (jsonObject.has("point_count")) {
-                // zoom-in to cluster
-                val bbox = pinsMapComponent?.getBboxForCluster(feature)
-                val target = bbox?.let { map?.getEnclosingCamera(it, Insets.NONE) }
-                target?.let { updateCameraPosition(300) {
-                    this.position = it.position
-                    // don't zoom in fully: leave some space to show the full pins, and limit max zoom
-                    this.zoom = (it.zoom - 0.25).coerceAtMost(19.0)
-                } }
+                pinsMapComponent?.zoomToCluster(feature)
                 return true
             }
             when (pinMode) {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MainMapFragment.kt
@@ -318,22 +318,22 @@ class MainMapFragment : MapFragment(), ShowsGeometryMarkers {
         // only query specific layer(s) - leaving layerIds empty would query all layers
         // result is already sorted by visual render order, descending
         val feature = map?.queryRenderedFeatures(searchArea,
-            "pins-layer", "pin-dot-layer", "overlay-symbols", "overlay-lines", "overlay-lines-dashed", "overlay-fills"
+            "pins-layer", "pin-cluster-layer", "overlay-symbols", "overlay-lines", "overlay-lines-dashed", "overlay-fills"
         )?.firstOrNull()
         val jsonObject = feature?.properties()
 
         if (jsonObject != null) {
+            if (jsonObject.has("point_count")) {
+                updateCameraPosition(300) {
+                    this.position = position.toLatLon()
+                    // this zooms so that the cluster splits into single elements or other clusters
+                    // getClusterChildren() and calculating bbox would be even better
+                    zoom = pinsMapComponent?.getClusterExpansionZoom(feature)?.coerceAtMost(19)?.toDouble()
+                }
+                return true
+            }
             when (pinMode) {
                 PinMode.QUESTS -> {
-                    if (jsonObject.has("point_count")) {
-                        updateCameraPosition(300) {
-                            this.position = position.toLatLon()
-                            // this zooms so that the cluster splits into single elements or other clusters
-                            // getClusterChildren() and calculating bbox would be even better
-                            zoom = pinsMapComponent?.getClusterExpansionZoom(feature)?.coerceAtMost(19)?.toDouble()
-                        }
-                        return true
-                    }
                     val properties = pinsMapComponent?.getProperties(jsonObject)
                     val questKey = properties?.let { questPinsManager?.getQuestKey(it) }
                     if (questKey != null) {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
@@ -15,8 +15,6 @@ import org.maplibre.android.style.sources.GeoJsonSource
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.screens.main.map.maplibre.clear
 import de.westnordost.streetcomplete.screens.main.map.maplibre.toPoint
-import de.westnordost.streetcomplete.util.logs.Log
-import org.maplibre.android.style.expressions.Expression
 import org.maplibre.android.style.sources.GeoJsonOptions
 
 /** Takes care of displaying pins on the map, e.g. quest pins or pins for recent edits */
@@ -91,7 +89,7 @@ class PinsMapComponent(private val map: MapLibreMap) {
 
     /** Show given pins. Previously shown pins are replaced with these.  */
     @UiThread fun set(pins: Collection<Pin>) {
-        val mapLibreFeatures = pins.sortedBy { it.order }.map { it.toFeature() }
+        val mapLibreFeatures = pins.sortedBy { it.order }.distinctBy { it.position }.map { it.toFeature() }
         pinsSource.setGeoJson(FeatureCollection.fromFeatures(mapLibreFeatures))
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
@@ -36,19 +36,27 @@ class PinsMapComponent(private val map: MapLibreMap) {
     //  avoid clustering for multiple quests on the same element
     //  maybe replace circles with pins with the number written on them?
     val layers: List<Layer> = listOf(
-        CircleLayer("pin-dot-layer", SOURCE)
-            .withFilter(all(gte(zoom(), 14f), lte(zoom(), 17f), gt(toNumber(get("point_count")), 1)))
+        CircleLayer("pin-cluster-layer", SOURCE)
+            .withFilter(all(gte(zoom(), 14f), lte(zoom(), CLUSTER_START_ZOOM), gt(toNumber(get("point_count")), 1)))
             .withProperties(
                 circleColor("white"),
                 circleStrokeColor("grey"),
                 circleRadius(sum(toNumber(literal(10f)), sqrt(get("point_count")))),
                 circleStrokeWidth(1f)
             ),
-        SymbolLayer("pin-dot-text-layer", SOURCE)
-            .withFilter(all(gte(zoom(), 14f), lte(zoom(), 17f), gt(toNumber(get("point_count")), 1)))
+        SymbolLayer("pin-cluster-text-layer", SOURCE)
+            .withFilter(all(gte(zoom(), 14f), lte(zoom(), CLUSTER_START_ZOOM), gt(toNumber(get("point_count")), 1)))
             .withProperties(
                 textField(get("point_count")),
                 textAllowOverlap(true) // avoid quest pins hiding number
+            ),
+        CircleLayer("pin-dot-layer", SOURCE)
+            .withFilter(gt(zoom(), CLUSTER_START_ZOOM))
+            .withProperties(
+                circleColor("white"),
+                circleStrokeColor("grey"),
+                circleRadius(5f),
+                circleStrokeWidth(1f)
             ),
         SymbolLayer("pins-layer", SOURCE)
             .withFilter(gte(zoom(), 16f))
@@ -94,6 +102,7 @@ class PinsMapComponent(private val map: MapLibreMap) {
 
     companion object {
         private const val SOURCE = "pins-source"
+        private const val CLUSTER_START_ZOOM = 17f
     }
 }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
@@ -14,11 +14,9 @@ import org.maplibre.android.style.layers.PropertyFactory.*
 import org.maplibre.android.style.layers.SymbolLayer
 import org.maplibre.android.style.sources.GeoJsonSource
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
-import de.westnordost.streetcomplete.screens.main.map.maplibre.CameraUpdate
 import de.westnordost.streetcomplete.screens.main.map.maplibre.clear
+import de.westnordost.streetcomplete.screens.main.map.maplibre.toLatLon
 import de.westnordost.streetcomplete.screens.main.map.maplibre.toPoint
-import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
-import de.westnordost.streetcomplete.util.logs.Log
 import de.westnordost.streetcomplete.util.math.enclosingBoundingBox
 import org.maplibre.android.style.sources.GeoJsonOptions
 import org.maplibre.geojson.Point
@@ -34,19 +32,11 @@ class PinsMapComponent(private val map: MapLibreMap) {
 //            .withClusterProperty(propertyName = , operatorExpr = , mapExpr = )
     )
 
-    fun getClusterExpansionZoom(feature: Feature) = pinsSource.getClusterExpansionZoom(feature)
-    fun getBboxForCluster(feature: Feature): BoundingBox {
+    fun getBboxForCluster(feature: Feature): BoundingBox? {
         val leaves = pinsSource.getClusterLeaves(feature, Long.MAX_VALUE, 0L)
-        val ll = mutableListOf<LatLon>()
-        leaves.features()?.forEach { ll.add((it.geometry()!! as Point).let { LatLon(it.latitude(), it.longitude()) }) }
-        return ll.enclosingBoundingBox()
-    }
-    fun getCamera(feature: Feature): BoundingBox {
-        CameraUpdate()
-        val leaves = pinsSource.getClusterLeaves(feature, Long.MAX_VALUE, 0L)
-        val ll = mutableListOf<LatLon>()
-        leaves.features()?.forEach { ll.add((it.geometry()!! as Point).let { LatLon(it.latitude(), it.longitude()) }) }
-        return ll.enclosingBoundingBox()
+        return leaves.features()
+            ?.mapNotNull { (it.geometry() as? Point)?.toLatLon() }
+            ?.enclosingBoundingBox()
     }
 
     // todo:

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
@@ -49,6 +49,7 @@ class PinsMapComponent(private val map: MapLibreMap) {
             .withFilter(all(gte(zoom(), 14f), lte(zoom(), CLUSTER_START_ZOOM), gt(toNumber(get("point_count")), 1)))
             .withProperties(
                 textField(get("point_count")),
+                textSize(sum(literal(15f), division(sqrt(get("point_count")), literal(2f)))),
                 textAllowOverlap(true) // avoid quest pins hiding number
             ),
         CircleLayer("pin-dot-layer", SOURCE)

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
@@ -27,9 +27,6 @@ class PinsMapComponent(private val map: MapLibreMap) {
         GeoJsonOptions()
             .withCluster(true)
             .withClusterMaxZoom(17)
-            // how does it work? needs other properties, so I guess it's not useful for us...
-            // though maybe it could help with the todo below?
-//            .withClusterProperty(propertyName = , operatorExpr = , mapExpr = )
     )
 
     fun getBboxForCluster(feature: Feature): BoundingBox? {
@@ -39,9 +36,6 @@ class PinsMapComponent(private val map: MapLibreMap) {
             ?.enclosingBoundingBox()
     }
 
-    // todo:
-    //  avoid clustering for multiple quests on the same element
-    //  maybe replace circles with pins with the number written on them?
     val layers: List<Layer> = listOf(
         CircleLayer("pin-cluster-layer", SOURCE)
             .withFilter(all(gte(zoom(), 14f), lte(zoom(), CLUSTER_START_ZOOM), gt(toNumber(get("point_count")), 1)))

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
@@ -16,6 +16,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.screens.main.map.maplibre.clear
 import de.westnordost.streetcomplete.screens.main.map.maplibre.toPoint
 import de.westnordost.streetcomplete.util.logs.Log
+import org.maplibre.android.style.expressions.Expression
 import org.maplibre.android.style.sources.GeoJsonOptions
 
 /** Takes care of displaying pins on the map, e.g. quest pins or pins for recent edits */
@@ -29,22 +30,25 @@ class PinsMapComponent(private val map: MapLibreMap) {
 //            .withClusterProperty(propertyName = , operatorExpr = , mapExpr = )
     )
 
+    fun getClusterExpansionZoom(feature: Feature) = pinsSource.getClusterExpansionZoom(feature)
+
     // todo:
     //  avoid clustering for multiple quests on the same element
-    //  maybe replace circles with some special pins, would look nicer
+    //  maybe replace circles with pins with the number written on them?
     val layers: List<Layer> = listOf(
         CircleLayer("pin-dot-layer", SOURCE)
             .withFilter(all(gte(zoom(), 14f), lte(zoom(), 17f), gt(toNumber(get("point_count")), 1)))
             .withProperties(
                 circleColor("white"),
                 circleStrokeColor("grey"),
-                circleRadius(12f), // is that dp? or should it be scaled with display size or something like that?
+                circleRadius(sum(toNumber(literal(10f)), sqrt(get("point_count")))),
                 circleStrokeWidth(1f)
             ),
         SymbolLayer("pin-dot-text-layer", SOURCE)
             .withFilter(all(gte(zoom(), 14f), lte(zoom(), 17f), gt(toNumber(get("point_count")), 1)))
             .withProperties(
                 textField(get("point_count")),
+                textAllowOverlap(true) // avoid quest pins hiding number
             ),
         SymbolLayer("pins-layer", SOURCE)
             .withFilter(gte(zoom(), 16f))

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
@@ -2,6 +2,7 @@ package de.westnordost.streetcomplete.screens.main.map.components
 
 import androidx.annotation.UiThread
 import com.google.gson.JsonObject
+import de.westnordost.streetcomplete.data.osm.mapdata.BoundingBox
 import org.maplibre.geojson.Feature
 import org.maplibre.geojson.FeatureCollection
 import org.maplibre.android.maps.MapLibreMap
@@ -13,9 +14,14 @@ import org.maplibre.android.style.layers.PropertyFactory.*
 import org.maplibre.android.style.layers.SymbolLayer
 import org.maplibre.android.style.sources.GeoJsonSource
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
+import de.westnordost.streetcomplete.screens.main.map.maplibre.CameraUpdate
 import de.westnordost.streetcomplete.screens.main.map.maplibre.clear
 import de.westnordost.streetcomplete.screens.main.map.maplibre.toPoint
+import de.westnordost.streetcomplete.util.ktx.nowAsEpochMilliseconds
+import de.westnordost.streetcomplete.util.logs.Log
+import de.westnordost.streetcomplete.util.math.enclosingBoundingBox
 import org.maplibre.android.style.sources.GeoJsonOptions
+import org.maplibre.geojson.Point
 
 /** Takes care of displaying pins on the map, e.g. quest pins or pins for recent edits */
 class PinsMapComponent(private val map: MapLibreMap) {
@@ -29,6 +35,19 @@ class PinsMapComponent(private val map: MapLibreMap) {
     )
 
     fun getClusterExpansionZoom(feature: Feature) = pinsSource.getClusterExpansionZoom(feature)
+    fun getBboxForCluster(feature: Feature): BoundingBox {
+        val leaves = pinsSource.getClusterLeaves(feature, Long.MAX_VALUE, 0L)
+        val ll = mutableListOf<LatLon>()
+        leaves.features()?.forEach { ll.add((it.geometry()!! as Point).let { LatLon(it.latitude(), it.longitude()) }) }
+        return ll.enclosingBoundingBox()
+    }
+    fun getCamera(feature: Feature): BoundingBox {
+        CameraUpdate()
+        val leaves = pinsSource.getClusterLeaves(feature, Long.MAX_VALUE, 0L)
+        val ll = mutableListOf<LatLon>()
+        leaves.features()?.forEach { ll.add((it.geometry()!! as Point).let { LatLon(it.latitude(), it.longitude()) }) }
+        return ll.enclosingBoundingBox()
+    }
 
     // todo:
     //  avoid clustering for multiple quests on the same element

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
@@ -24,18 +24,27 @@ class PinsMapComponent(private val map: MapLibreMap) {
         GeoJsonOptions()
             .withCluster(true)
             .withClusterMaxZoom(17)
-        // how does it work?
+            // how does it work? needs other properties, so I guess it's not useful for us...
+            // though maybe it could help with the todo below?
 //            .withClusterProperty(propertyName = , operatorExpr = , mapExpr = )
     )
 
+    // todo:
+    //  avoid clustering for multiple quests on the same element
+    //  maybe replace circles with some special pins, would look nicer
     val layers: List<Layer> = listOf(
         CircleLayer("pin-dot-layer", SOURCE)
-            .withFilter(gte(zoom(), 14f))
+            .withFilter(all(gte(zoom(), 14f), lte(zoom(), 17f), gt(toNumber(get("point_count")), 1)))
             .withProperties(
                 circleColor("white"),
                 circleStrokeColor("grey"),
-                circleRadius(toNumber(get("point_count"))),
+                circleRadius(12f), // is that dp? or should it be scaled with display size or something like that?
                 circleStrokeWidth(1f)
+            ),
+        SymbolLayer("pin-dot-text-layer", SOURCE)
+            .withFilter(all(gte(zoom(), 14f), lte(zoom(), 17f), gt(toNumber(get("point_count")), 1)))
+            .withProperties(
+                textField(get("point_count")),
             ),
         SymbolLayer("pins-layer", SOURCE)
             .withFilter(gte(zoom(), 16f))

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/PinsMapComponent.kt
@@ -15,10 +15,18 @@ import org.maplibre.android.style.sources.GeoJsonSource
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.screens.main.map.maplibre.clear
 import de.westnordost.streetcomplete.screens.main.map.maplibre.toPoint
+import de.westnordost.streetcomplete.util.logs.Log
+import org.maplibre.android.style.sources.GeoJsonOptions
 
 /** Takes care of displaying pins on the map, e.g. quest pins or pins for recent edits */
 class PinsMapComponent(private val map: MapLibreMap) {
-    private val pinsSource = GeoJsonSource(SOURCE)
+    private val pinsSource = GeoJsonSource(SOURCE,
+        GeoJsonOptions()
+            .withCluster(true)
+            .withClusterMaxZoom(17)
+        // how does it work?
+//            .withClusterProperty(propertyName = , operatorExpr = , mapExpr = )
+    )
 
     val layers: List<Layer> = listOf(
         CircleLayer("pin-dot-layer", SOURCE)
@@ -26,7 +34,7 @@ class PinsMapComponent(private val map: MapLibreMap) {
             .withProperties(
                 circleColor("white"),
                 circleStrokeColor("grey"),
-                circleRadius(5f),
+                circleRadius(toNumber(get("point_count"))),
                 circleStrokeWidth(1f)
             ),
         SymbolLayer("pins-layer", SOURCE)

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/maplibre/Camera.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/maplibre/Camera.kt
@@ -6,11 +6,18 @@ import androidx.core.graphics.Insets
 import org.maplibre.android.camera.CameraUpdateFactory
 import org.maplibre.android.maps.MapLibreMap
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.BoundingBox
 import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 
 fun MapLibreMap.getEnclosingCamera(geometry: ElementGeometry, insets: Insets): CameraPosition? =
     getCameraForGeometry(
         geometry.toMapLibreGeometry(),
+        intArrayOf(insets.left, insets.top, insets.right, insets.bottom)
+    )?.toCameraPosition()
+
+fun MapLibreMap.getEnclosingCamera(bbox: BoundingBox, insets: Insets): CameraPosition? =
+    getCameraForLatLngBounds(
+        bbox.toLatLngBounds(),
         intArrayOf(insets.left, insets.top, insets.right, insets.bottom)
     )?.toCameraPosition()
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/maplibre/Position.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/maplibre/Position.kt
@@ -30,6 +30,9 @@ fun MapLibreMap.screenAreaToBoundingBox(): BoundingBox =
 fun LatLngBounds.toBoundingBox() =
     BoundingBox(latitudeSouth, longitudeWest, latitudeNorth, longitudeEast)
 
+fun BoundingBox.toLatLngBounds() =
+    LatLngBounds.from(max.latitude, max.longitude, min.latitude, min.longitude)
+
 fun LatLng.toLatLon() = LatLon(latitude, longitude)
 fun LatLon.toLatLng() = LatLng(latitude, longitude)
 
@@ -93,5 +96,6 @@ fun ElementPolygonsGeometry.toMapLibreGeometry(): Geometry {
 }
 
 fun LatLon.toPoint(): Point = Point.fromLngLat(longitude, latitude)
+fun Point.toLatLon(): LatLon = LatLon(latitude(), longitude())
 
 fun GeoJsonSource.clear() = setGeoJson(FeatureCollection.fromFeatures(emptyList()))


### PR DESCRIPTION
This is still very basic, it only increases quest dot radius with `point_count`.
Since we want to get rid of quest dots, this is obviously only some sort of demo / playground.

Currently
* I don't understand what `withClusterProperty` is doing
* I don't have an idea how the clusters should look like
* I don't know what should happen when selecting a cluster (Zoom in? Open the highest priority quest? Show all contained quests? Nothing?

Help for continuing:
https://maplibre.org/maplibre-gl-js/docs/examples/cluster/
https://github.com/maplibre/maplibre-native/blob/main/platform/android/MapLibreAndroidTestApp/src/main/java/org/maplibre/android/testapp/activity/style/GeoJsonClusteringActivity.kt