### PR TITLE
fixes #547 : Auto-complete not working for tree names with whitespace

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/tree/AddTreeGenusForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/tree/AddTreeGenusForm.kt
@@ -95,10 +95,11 @@ class AddTreeGenusForm : AbstractOsmQuestForm<Tree>() {
         }
         return trees.filter { tree ->
             tree.toDisplayString() == search
-            || tree.name == search
-            || tree.name.split(" ").any { it.startsWith(search, true) }
-            || tree.localName?.contains(search, true) == true
-        //sorting: genus-only first, then prefer trees with localName
+                || tree.toDisplayString().startsWith(search, true)
+                || tree.name == search
+                || tree.name.split(" ").any { it.startsWith(search, true) }
+                || tree.localName?.contains(search, true) == true
+            //sorting: genus-only first, then prefer trees with localName
         }.sortedBy { it.localName == null }.sortedBy { it.isSpecies }
     }
 


### PR DESCRIPTION
It was quite simple, you didn't have to do a split and you also had to look at the display, otherwise the user didn't really understand why you were taking away a suggestion. 

The configuration of my Android Studio keeps trying to modify the stewardship, I've tried to remove it only on this project but I haven't really succeeded, sorry. 