### PR TITLE
Fix when changing between 2 custom overlays

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/data/overlays/SelectedOverlayController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/overlays/SelectedOverlayController.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.data.overlays
 import com.russhwolf.settings.ObservableSettings
 import de.westnordost.streetcomplete.Prefs
 import de.westnordost.streetcomplete.overlays.Overlay
+import de.westnordost.streetcomplete.overlays.custom.CustomOverlay
 import de.westnordost.streetcomplete.util.Listeners
 
 class SelectedOverlayController(
@@ -12,17 +13,25 @@ class SelectedOverlayController(
 
     private val listeners = Listeners<SelectedOverlaySource.Listener>()
 
-    override var selectedOverlay: Overlay?
+    private val selectedOverlayByPref =
+        prefs.getStringOrNull(Prefs.SELECTED_OVERLAY)?.let {
+            if (it.contains(CustomOverlay::class.simpleName.toString())) {
+                overlayRegistry.getByName(CustomOverlay::class.simpleName!!)
+            } else {
+                overlayRegistry.getByName(it)
+            }
+        }
+
+    override var selectedOverlay: Overlay? = selectedOverlayByPref
         set(value) {
-            if (value != null && value in overlayRegistry) {
+            field = value
+            if (value != null && value in overlayRegistry || value is Overlay) {
                 prefs.putString(Prefs.SELECTED_OVERLAY, value.name)
             } else {
-
                 prefs.remove(Prefs.SELECTED_OVERLAY)
             }
             listeners.forEach { it.onSelectedOverlayChanged() }
         }
-        get() = prefs.getStringOrNull(Prefs.SELECTED_OVERLAY)?.let { overlayRegistry.getByName(it) }
 
     override fun addListener(listener: SelectedOverlaySource.Listener) {
         listeners.add(listener)

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/custom/CustomOverlay.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/custom/CustomOverlay.kt
@@ -25,7 +25,6 @@ import de.westnordost.streetcomplete.util.ktx.isArea
 
 class CustomOverlay(
     val prefs: ObservableSettings,
-    override val name: String = CustomOverlay::class.simpleName.toString(),
     @StringRes override val title: Int = R.string.custom_overlay_title,
     @DrawableRes override val icon: Int = R.drawable.ic_custom_overlay,
     override val changesetComment: String = "Edit user-defined element selection",

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/custom/CustomOverlay.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/custom/CustomOverlay.kt
@@ -1,6 +1,8 @@
 package de.westnordost.streetcomplete.overlays.custom
 
 import android.content.SharedPreferences
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import com.russhwolf.settings.ObservableSettings
 import de.westnordost.streetcomplete.Prefs
 import de.westnordost.streetcomplete.R
@@ -21,12 +23,15 @@ import de.westnordost.streetcomplete.overlays.StrokeStyle
 import de.westnordost.streetcomplete.util.getNameLabel
 import de.westnordost.streetcomplete.util.ktx.isArea
 
-class CustomOverlay(val prefs: ObservableSettings) : Overlay {
-
-    override val title = R.string.custom_overlay_title
-    override val icon = R.drawable.ic_custom_overlay
-    override val changesetComment = "Edit user-defined element selection"
+class CustomOverlay(
+    val prefs: ObservableSettings,
+    override val name: String = CustomOverlay::class.simpleName.toString(),
+    @StringRes override val title: Int = R.string.custom_overlay_title,
+    @DrawableRes override val icon: Int = R.drawable.ic_custom_overlay,
+    override val changesetComment: String = "Edit user-defined element selection",
     override val wikiLink: String = "Tags"
+) : Overlay {
+
     override val isCreateNodeEnabled get() = prefs.getString(Prefs.CUSTOM_OVERLAY_IDX_FILTER, "").startsWith("nodes")
 
     override fun getStyledElements(mapData: MapDataWithGeometry): Sequence<Pair<Element, Style>> {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/MainFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/MainFragment.kt
@@ -1159,11 +1159,9 @@ class MainFragment :
         popupWindow.setAdapter(adapter)
         popupWindow.setOnItemClickListener { _, _, position, _ ->
 //            controlsViewModel.selectOverlay(adapter.getItem(position)) would be nice to do it like this, but not improtant right now
-            var selectedOverlay = adapter.getItem(position)
+            val selectedOverlay = adapter.getItem(position)
             if (selectedOverlay?.title == 0) {
                 prefs.putInt(Prefs.CUSTOM_OVERLAY_SELECTED_INDEX, selectedOverlay.wikiLink!!.toInt())
-                // set the actual custom overlay instead of the fake one
-                selectedOverlay = overlayRegistry.getByName(CustomOverlay::class.simpleName!!)
             }
             if (selectedOverlay == null && position != 0) {
                 val newIdx = if (prefs.getString(Prefs.CUSTOM_OVERLAY_INDICES, "0").isBlank()) 0

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/MainViewModelImpl.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/MainViewModelImpl.kt
@@ -74,9 +74,6 @@ class MainViewModelImpl(
         send(selectedOverlayController.selectedOverlay)
         val listener = object : SelectedOverlaySource.Listener {
             override fun onSelectedOverlayChanged() {
-                if (selectedOverlayController.selectedOverlay is CustomOverlay) {
-                    trySend(null) // todo: sometimes this is not helping, button stays the same
-                }
                 trySend(selectedOverlayController.selectedOverlay)
             }
         }

--- a/app/src/main/java/de/westnordost/streetcomplete/util/OverlayHelpers.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/OverlayHelpers.kt
@@ -26,6 +26,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
 import de.westnordost.streetcomplete.overlays.Overlay
 import de.westnordost.streetcomplete.overlays.Style
+import de.westnordost.streetcomplete.overlays.custom.CustomOverlay
 import de.westnordost.streetcomplete.overlays.custom.getCustomOverlayIndices
 import de.westnordost.streetcomplete.overlays.custom.getIndexedCustomOverlayPref
 import de.westnordost.streetcomplete.util.dialogs.setViewWithDefaultPadding
@@ -245,22 +246,17 @@ fun getFakeCustomOverlays(prefs: ObservableSettings, ctx: Context, onlyIfExpertM
     if (onlyIfExpertMode && !prefs.getBoolean(Prefs.EXPERT_MODE, false)) return emptyList()
     return prefs.getString(Prefs.CUSTOM_OVERLAY_INDICES, "0").split(",").mapNotNull { index ->
         val i = index.toIntOrNull() ?: return@mapNotNull null
-        object : Overlay {
-            override fun getStyledElements(mapData: MapDataWithGeometry) = emptySequence<Pair<Element, Style>>()
-            override fun createForm(element: Element?) = null
-            override val changesetComment = prefs.getString(getIndexedCustomOverlayPref(Prefs.CUSTOM_OVERLAY_IDX_NAME, i), "")
-                .ifBlank { ctx.getString(R.string.custom_overlay_title) } // displayed overlay name
-            override val icon = ctx.resources.getIdentifier(
+        CustomOverlay(
+            prefs=prefs,
+            name = CustomOverlay::class.simpleName +"_"+ index, // allows to uniquely identify an overlay
+                title = 0, // use invalid resId placeholder, the adapter needs to be aware of this
+            icon = ctx.resources.getIdentifier(
                 prefs.getString(getIndexedCustomOverlayPref(Prefs.CUSTOM_OVERLAY_IDX_ICON, i), "ic_custom_overlay"),
                 "drawable", ctx.packageName
-            ).takeIf { it != 0 } ?: R.drawable.ic_custom_overlay
-            override val title = 0 // use invalid resId placeholder, the adapter needs to be aware of this
-            override val name = index // allows to uniquely identify an overlay
-            override val wikiLink = index
-            override fun equals(other: Any?): Boolean {
-                return if (other !is Overlay) false
-                    else wikiLink == other.wikiLink // we only care about index!
-            }
-        }
+            ).takeIf { it != 0 } ?: R.drawable.ic_custom_overlay,
+            changesetComment = prefs.getString(getIndexedCustomOverlayPref(Prefs.CUSTOM_OVERLAY_IDX_NAME, i), "")
+                .ifBlank { ctx.getString(R.string.custom_overlay_title) }, // displayed overlay name
+            wikiLink = index
+        )
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/util/OverlayHelpers.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/OverlayHelpers.kt
@@ -242,19 +242,30 @@ fun showOverlayCustomizer(
 // title is invalid resId 0
 // name and wikiLink are the overlay index as stored in shared preferences
 // changesetComment is the overlay title
-fun getFakeCustomOverlays(prefs: ObservableSettings, ctx: Context, onlyIfExpertMode: Boolean = true): List<Overlay> {
+fun getFakeCustomOverlays(
+    prefs: ObservableSettings,
+    ctx: Context,
+    onlyIfExpertMode: Boolean = true
+): List<Overlay> {
     if (onlyIfExpertMode && !prefs.getBoolean(Prefs.EXPERT_MODE, false)) return emptyList()
     return prefs.getString(Prefs.CUSTOM_OVERLAY_INDICES, "0").split(",").mapNotNull { index ->
         val i = index.toIntOrNull() ?: return@mapNotNull null
         CustomOverlay(
-            prefs=prefs,
-            name = CustomOverlay::class.simpleName +"_"+ index, // allows to uniquely identify an overlay
-                title = 0, // use invalid resId placeholder, the adapter needs to be aware of this
+            prefs = prefs,
+            title = 0, // use invalid resId placeholder, the adapter needs to be aware of this
             icon = ctx.resources.getIdentifier(
-                prefs.getString(getIndexedCustomOverlayPref(Prefs.CUSTOM_OVERLAY_IDX_ICON, i), "ic_custom_overlay"),
+                prefs.getString(
+                    getIndexedCustomOverlayPref(Prefs.CUSTOM_OVERLAY_IDX_ICON, i),
+                    "ic_custom_overlay"
+                ),
                 "drawable", ctx.packageName
             ).takeIf { it != 0 } ?: R.drawable.ic_custom_overlay,
-            changesetComment = prefs.getString(getIndexedCustomOverlayPref(Prefs.CUSTOM_OVERLAY_IDX_NAME, i), "")
+            changesetComment = prefs.getString(
+                getIndexedCustomOverlayPref(
+                    Prefs.CUSTOM_OVERLAY_IDX_NAME,
+                    i
+                ), ""
+            )
                 .ifBlank { ctx.getString(R.string.custom_overlay_title) }, // displayed overlay name
             wikiLink = index
         )


### PR DESCRIPTION
I noticed that when I changed the overlay between 2 customs the icon didn't update.
There was even the beginnings of a fix in the code, but that doesn't change anything because it wasn't a view refresh problem.

This is due to the fact that the reference was not changed because there is only one instance in the OverlayRegistry.

- [x]  So I've changed it to use a reference on the objects. 
- [x]  I've also removed the need to always look at the prefs (pref level is not recommended by google and it's not even asynchronous).

I hope it won't be a problem during the rebases with SC



