### PR TITLE
Fix: Changing the text in the menu according to the filter

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/questselection/QuestSelectionFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/questselection/QuestSelectionFragment.kt
@@ -113,6 +113,12 @@ class QuestSelectionFragment : TwoPaneDetailFragment(R.layout.fragment_quest_sel
                 }
                 3 -> {
                     questSelectionAdapter.onlySceeQuests = !questSelectionAdapter.onlySceeQuests
+                    if(questSelectionAdapter.onlySceeQuests){
+                        toolbar.menu.findItem(3).setTitle(R.string.action_all_quests)
+                    }else{
+                        toolbar.menu.findItem(3).setTitle(R.string.action_scee_quests)
+                    }
+
                     true
                 }
                 else -> false

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/questselection/QuestSelectionFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/questselection/QuestSelectionFragment.kt
@@ -113,9 +113,9 @@ class QuestSelectionFragment : TwoPaneDetailFragment(R.layout.fragment_quest_sel
                 }
                 3 -> {
                     questSelectionAdapter.onlySceeQuests = !questSelectionAdapter.onlySceeQuests
-                    if(questSelectionAdapter.onlySceeQuests){
+                    if (questSelectionAdapter.onlySceeQuests){
                         toolbar.menu.findItem(3).setTitle(R.string.action_all_quests)
-                    }else{
+                    } else {
                         toolbar.menu.findItem(3).setTitle(R.string.action_scee_quests)
                     }
 

--- a/app/src/main/res/values/strings_ee.xml
+++ b/app/src/main/res/values/strings_ee.xml
@@ -180,6 +180,7 @@
     <string name="pref_interval_summary">%d seconds</string>
     <string name="pref_interval_message">Update interval in seconds</string>
     <string name="action_scee_quests">Show only SCEE quests</string>
+    <string name="action_all_quests">Show all quests</string>
     <string name="restore_dialog_hint">You can also manually choose which quests to restore by long-pressing the undo button.</string>
 
 


### PR DESCRIPTION
I noticed that the text "Show only SCEE quests" didn't change. This is annoying because when the filter is activated, clicking on "Show only SCEE quests" displays all the quests.
I suggest having a different text.

![Screenshot_20240703_073824](https://github.com/Helium314/SCEE/assets/3765114/6e25b072-557b-41e2-9387-001410c1ed97)
![Screenshot_20240703_073842](https://github.com/Helium314/SCEE/assets/3765114/5407a60d-14e2-4fee-aeaf-fef568125f29)
