### PR TITLE
Fixes #570 Don't display quest Trail visibility when it's private

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/trail_visibility/AddTrailVisibility.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/trail_visibility/AddTrailVisibility.kt
@@ -14,6 +14,8 @@ class AddTrailVisibility : OsmFilterQuestType<TrailVisibility>() {
         ways with
           highway ~ path|footway|cycleway|bridleway
           and !trail_visibility
+          and access !~ no|private
+          and foot !~ no|private
           and (sac_scale and sac_scale != hiking)
           and (!lit or lit = no)
           and surface ~ "ground|earth|dirt|soil|grass|sand|mud|ice|salt|snow|rock|stone"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/trail_visibility/AddTrailVisibility.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/trail_visibility/AddTrailVisibility.kt
@@ -14,8 +14,7 @@ class AddTrailVisibility : OsmFilterQuestType<TrailVisibility>() {
         ways with
           highway ~ path|footway|cycleway|bridleway
           and !trail_visibility
-          and access !~ no|private
-          and foot !~ no|private
+          and ( access !~ no|private or foot ~ yes|permissive|designated or bicycle ~ yes|permissive|designated)
           and (sac_scale and sac_scale != hiking)
           and (!lit or lit = no)
           and surface ~ "ground|earth|dirt|soil|grass|sand|mud|ice|salt|snow|rock|stone"


### PR DESCRIPTION
Don't display quest Trail visibility when it's private


If users want to go there, they can modify the request.
As far as I'm concerned, we shouldn't insist on going beyond the rules.