### PR TITLE
add title on fragment scee

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DataManagementSettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DataManagementSettingsFragment.kt
@@ -7,12 +7,14 @@ import android.content.SharedPreferences
 import android.net.Uri
 import android.os.Bundle
 import android.os.Environment
+import android.view.View
 import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SwitchCompat
+import androidx.appcompat.widget.Toolbar
 import androidx.core.app.ActivityCompat
 import androidx.core.content.edit
 import androidx.core.os.bundleOf
@@ -49,6 +51,7 @@ import de.westnordost.streetcomplete.screens.HasTitle
 import de.westnordost.streetcomplete.util.TempLogger
 import de.westnordost.streetcomplete.util.dialogs.setViewWithDefaultPadding
 import de.westnordost.streetcomplete.util.getFakeCustomOverlays
+import de.westnordost.streetcomplete.util.ktx.setUpToolbarTitleAndIcon
 import de.westnordost.streetcomplete.util.ktx.toast
 import de.westnordost.streetcomplete.util.logs.DatabaseLogger
 import de.westnordost.streetcomplete.util.logs.Log
@@ -82,6 +85,13 @@ class DataManagementSettingsFragment :
 
     override val title: String get() = getString(R.string.pref_screen_data_management)
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        view.findViewById<Toolbar>(R.id.toolbar).apply {
+            setUpToolbarTitleAndIcon(this)
+        }
+    }
+    
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         PreferenceManager.setDefaultValues(requireContext(), R.xml.preferences_ee_data_management, false)
         addPreferencesFromResource(R.xml.preferences_ee_data_management)

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DisplaySettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DisplaySettingsFragment.kt
@@ -6,11 +6,13 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Bundle
 import android.provider.OpenableColumns
+import android.view.View
 import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SwitchCompat
+import androidx.appcompat.widget.Toolbar
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
@@ -29,6 +31,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.visiblequests.VisibleQuestTypeController
 import de.westnordost.streetcomplete.screens.HasTitle
 import de.westnordost.streetcomplete.util.dialogs.setViewWithDefaultPadding
+import de.westnordost.streetcomplete.util.ktx.setUpToolbarTitleAndIcon
 import de.westnordost.streetcomplete.util.ktx.toast
 import de.westnordost.streetcomplete.util.logs.Log
 import de.westnordost.streetcomplete.util.math.area
@@ -51,6 +54,13 @@ class DisplaySettingsFragment :
     private val downloadController: DownloadController by inject()
 
     override val title: String get() = getString(R.string.pref_screen_display)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        view.findViewById<Toolbar>(R.id.toolbar).apply {
+            setUpToolbarTitleAndIcon(this)
+        }
+    }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         PreferenceManager.setDefaultValues(requireContext(), R.xml.preferences_ee_display, false)

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/NoteSettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/NoteSettingsFragment.kt
@@ -5,10 +5,12 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.text.InputType
+import android.view.View
 import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.widget.Toolbar
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
@@ -19,6 +21,7 @@ import de.westnordost.streetcomplete.data.osm.osmquests.OsmQuestController
 import de.westnordost.streetcomplete.data.osmnotes.notequests.getRawBlockList
 import de.westnordost.streetcomplete.screens.HasTitle
 import de.westnordost.streetcomplete.util.dialogs.setDefaultDialogPadding
+import de.westnordost.streetcomplete.util.ktx.setUpToolbarTitleAndIcon
 import de.westnordost.streetcomplete.util.ktx.toast
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -34,6 +37,13 @@ class NoteSettingsFragment : PreferenceFragmentCompat(), HasTitle {
     private val prefs: ObservableSettings by inject()
 
     override val title: String get() = getString(R.string.pref_screen_notes)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        view.findViewById<Toolbar>(R.id.toolbar).apply {
+            setUpToolbarTitleAndIcon(this)
+        }
+    }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         PreferenceManager.setDefaultValues(requireContext(), R.xml.preferences_ee_notes, false)

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/QuestsSettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/QuestsSettingsFragment.kt
@@ -7,12 +7,14 @@ import android.content.SharedPreferences
 import android.os.Build
 import android.os.Bundle
 import android.text.InputType
+import android.view.View
 import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SwitchCompat
+import androidx.appcompat.widget.Toolbar
 import androidx.core.app.ActivityCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.Preference
@@ -30,6 +32,7 @@ import de.westnordost.streetcomplete.screens.HasTitle
 import de.westnordost.streetcomplete.util.dialogs.setViewWithDefaultPadding
 import de.westnordost.streetcomplete.util.ktx.dpToPx
 import de.westnordost.streetcomplete.util.ktx.hasPermission
+import de.westnordost.streetcomplete.util.ktx.setUpToolbarTitleAndIcon
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
@@ -46,6 +49,13 @@ class QuestsSettingsFragment :
     private val questTypeOrderController: QuestTypeOrderController by inject()
 
     override val title: String get() = getString(R.string.pref_screen_quests)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        view.findViewById<Toolbar>(R.id.toolbar).apply {
+            setUpToolbarTitleAndIcon(this)
+        }
+    }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         PreferenceManager.setDefaultValues(requireContext(), R.xml.preferences_ee_quests, false)

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/UiSettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/UiSettingsFragment.kt
@@ -3,12 +3,14 @@ package de.westnordost.streetcomplete.screens.settings
 import android.annotation.SuppressLint
 import android.os.Bundle
 import android.text.InputType
+import android.view.View
 import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.RadioButton
 import android.widget.RadioGroup
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.widget.Toolbar
 import androidx.core.os.bundleOf
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
@@ -18,6 +20,7 @@ import de.westnordost.streetcomplete.Prefs
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.screens.HasTitle
 import de.westnordost.streetcomplete.util.dialogs.setViewWithDefaultPadding
+import de.westnordost.streetcomplete.util.ktx.setUpToolbarTitleAndIcon
 import org.koin.android.ext.android.inject
 
 class UiSettingsFragment : PreferenceFragmentCompat(), HasTitle {
@@ -25,6 +28,13 @@ class UiSettingsFragment : PreferenceFragmentCompat(), HasTitle {
     private val prefs: ObservableSettings by inject()
 
     override val title: String get() = getString(R.string.pref_screen_ui)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        view.findViewById<Toolbar>(R.id.toolbar).apply {
+            setUpToolbarTitleAndIcon(this)
+        }
+    }
 
     @SuppressLint("ResourceType") // for nearby quests... though it could probably be done in a nicer way
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {


### PR DESCRIPTION
I realised that for the fragments that SCEE also had, the title and navigation icon were missing.

So I modified the fragments so that they now work. In any case on my 2 available phones.

Example:

![Screenshot_20240707_084036](https://github.com/Helium314/SCEE/assets/3765114/040aca4e-f639-44a0-9738-74bfa9540b2f)
