### PR TITLE
Fix: add title on fragment scee

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DataManagementSettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DataManagementSettingsFragment.kt
@@ -84,7 +84,7 @@ class DataManagementSettingsFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        view.findViewById<Toolbar>(R.id.toolbar)?.apply {
+        view.rootView.findViewById<Toolbar>(R.id.toolbar)?.apply {
             setUpToolbarTitleAndIcon(this)
         }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DisplaySettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DisplaySettingsFragment.kt
@@ -49,7 +49,7 @@ class DisplaySettingsFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        view.findViewById<Toolbar>(R.id.toolbar)?.apply {
+        view.rootView.findViewById<Toolbar>(R.id.toolbar)?.apply {
             setUpToolbarTitleAndIcon(this)
         }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/NoteSettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/NoteSettingsFragment.kt
@@ -40,7 +40,7 @@ class NoteSettingsFragment : PreferenceFragmentCompat(), HasTitle {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        view.findViewById<Toolbar>(R.id.toolbar)?.apply {
+        view.rootView.findViewById<Toolbar>(R.id.toolbar)?.apply {
             setUpToolbarTitleAndIcon(this)
         }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/QuestsSettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/QuestsSettingsFragment.kt
@@ -53,7 +53,7 @@ class QuestsSettingsFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        view.findViewById<Toolbar>(R.id.toolbar)?.apply {
+        view.rootView.findViewById<Toolbar>(R.id.toolbar)?.apply {
             setUpToolbarTitleAndIcon(this)
         }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/SettingsActivity.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/SettingsActivity.kt
@@ -7,7 +7,13 @@ import android.location.LocationManager
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.widget.Toolbar
+import androidx.compose.material.IconButton
 import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import androidx.core.app.ActivityCompat
 import androidx.core.os.bundleOf
 import androidx.core.view.isGone
@@ -35,6 +41,7 @@ import de.westnordost.streetcomplete.databinding.ActivitySettingsBinding
 import de.westnordost.streetcomplete.quests.AbstractOsmQuestForm
 import de.westnordost.streetcomplete.quests.AbstractQuestForm
 import de.westnordost.streetcomplete.screens.BaseActivity
+import de.westnordost.streetcomplete.ui.common.BackIcon
 import de.westnordost.streetcomplete.ui.theme.AppTheme
 import de.westnordost.streetcomplete.util.math.translate
 import de.westnordost.streetcomplete.util.viewBinding
@@ -197,6 +204,7 @@ class SettingsActivity : BaseActivity(), AbstractOsmQuestForm.Listener {
     private fun updateContainerVisibility() {
         binding.questFormContainer.isGone = supportFragmentManager.findFragmentById(R.id.questForm) == null
         binding.sceeSettingsFragmentContainer.isGone = supportFragmentManager.findFragmentById(R.id.sceeSettingsFragment) == null
+        binding.toolbar.toolbar.isGone = supportFragmentManager.findFragmentById(R.id.sceeSettingsFragment) == null
     }
 
     private fun createMockElementWithGeometry(questType: OsmElementQuestType<*>): Pair<Element, ElementGeometry> {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/UiSettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/UiSettingsFragment.kt
@@ -3,6 +3,7 @@ package de.westnordost.streetcomplete.screens.settings
 import android.annotation.SuppressLint
 import android.os.Bundle
 import android.text.InputType
+import android.util.Log
 import android.view.View
 import android.widget.EditText
 import android.widget.LinearLayout
@@ -32,7 +33,7 @@ class UiSettingsFragment : PreferenceFragmentCompat(), HasTitle {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        view.findViewById<Toolbar>(R.id.toolbar)?.apply {
+        view.rootView.findViewById<Toolbar>(R.id.toolbar)?.apply {
             setUpToolbarTitleAndIcon(this)
         }
     }

--- a/app/src/main/java/de/westnordost/streetcomplete/util/ktx/Fragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/ktx/Fragment.kt
@@ -1,6 +1,7 @@
 package de.westnordost.streetcomplete.util.ktx
 
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.isGone
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Lifecycle
@@ -35,6 +36,7 @@ fun Fragment.setUpToolbarTitleAndIcon(toolbar: Toolbar) {
     }
 
     toolbar.navigationIcon = backIcon
+    toolbar.isGone = false
 }
 
 fun <T> Fragment.observe(flow: SharedFlow<T>, collector: FlowCollector<T>) {

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -16,10 +16,17 @@
         android:background="@color/background"
         android:visibility="gone" >
 
+        <include layout="@layout/toolbar"
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+
         <RelativeLayout
             android:id="@+id/sceeSettingsFragment"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="0dp"
+            android:layout_below="@id/toolbar"
+            android:layout_alignParentBottom="true"/>
 
     </RelativeLayout>
 

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="primary">#ff222222</color>
+
     <color name="accent">#ff6600</color>
     <color name="accent_variant">#F44336</color>
 


### PR DESCRIPTION
I've corrected it to put the toolbar back on the scee fragments. 
It's not perfect in terms of theme, but it'll be fixed the day it goes to compose.

![Screenshot_20240805_135045](https://github.com/user-attachments/assets/2a20fbcf-c1d1-4a76-a335-33c024a6affc)
![Screenshot_20240805_135021](https://github.com/user-attachments/assets/222f4979-49b4-4b7b-be90-bd261e9789a5)
