### PR TITLE
Add vertical divider between search results and shortcuts

### DIFF
--- a/app/src/main/res/layout/view_select_preset.xml
+++ b/app/src/main/res/layout/view_select_preset.xml
@@ -42,6 +42,15 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
+    <View
+        android:id="@+id/verticalDivider"
+        android:layout_width="1dp"
+        android:layout_height="0dp"
+        android:background="@color/divider"
+        app:layout_constraintTop_toBottomOf="@+id/searchEditText"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/shortcutScrollView" />
+
     <ScrollView
         android:id="@+id/shortcutScrollView"
         android:visibility="gone"

--- a/app/src/main/res/layout/view_select_preset.xml
+++ b/app/src/main/res/layout/view_select_preset.xml
@@ -47,6 +47,8 @@
         android:layout_width="1dp"
         android:layout_height="0dp"
         android:background="@color/divider"
+        android:layout_marginStart="2dp"
+        android:layout_marginEnd="2dp"
         app:layout_constraintTop_toBottomOf="@+id/searchEditText"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/shortcutScrollView" />

--- a/app/src/main/res/layout/view_select_preset.xml
+++ b/app/src/main/res/layout/view_select_preset.xml
@@ -66,9 +66,9 @@
             android:id="@+id/shortcuts"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="12dp"
             android:elevation="2dp"
             android:paddingVertical="8dp"
+            android:paddingRight="12dp"
             android:orientation="vertical" />
 
     </ScrollView>

--- a/app/src/main/res/layout/view_select_preset.xml
+++ b/app/src/main/res/layout/view_select_preset.xml
@@ -48,7 +48,7 @@
         android:layout_height="0dp"
         android:background="@color/divider"
         android:layout_marginStart="2dp"
-        android:layout_marginEnd="2dp"
+        android:layout_marginEnd="12dp"
         app:layout_constraintTop_toBottomOf="@+id/searchEditText"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/shortcutScrollView" />

--- a/app/src/main/res/layout/view_select_preset.xml
+++ b/app/src/main/res/layout/view_select_preset.xml
@@ -58,7 +58,7 @@
         android:visibility="gone"
         android:layout_width="58dp"
         android:layout_height="0dp"
-        android:layout_marginEnd="16dp"
+        android:layout_marginEnd="12dp"
         app:layout_constraintTop_toBottomOf="@+id/searchEditText"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintRight_toRightOf="parent" >

--- a/app/src/main/res/layout/view_select_preset.xml
+++ b/app/src/main/res/layout/view_select_preset.xml
@@ -66,6 +66,7 @@
             android:id="@+id/shortcuts"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
             android:elevation="2dp"
             android:paddingVertical="8dp"
             android:orientation="vertical" />

--- a/app/src/main/res/layout/view_select_preset.xml
+++ b/app/src/main/res/layout/view_select_preset.xml
@@ -58,6 +58,7 @@
         android:visibility="gone"
         android:layout_width="58dp"
         android:layout_height="0dp"
+        android:layout_marginEnd="16dp"
         app:layout_constraintTop_toBottomOf="@+id/searchEditText"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintRight_toRightOf="parent" >
@@ -68,7 +69,6 @@
             android:layout_height="wrap_content"
             android:elevation="2dp"
             android:paddingVertical="8dp"
-            android:paddingRight="12dp"
             android:orientation="vertical" />
 
     </ScrollView>


### PR DESCRIPTION
Fixes https://github.com/Helium314/SCEE/issues/656 (where lack of divider were introducing confusion). 

<details>
<summary>(updated) screenshot</summary>

(Tested in https://github.com/mnalis/StreetComplete/actions/runs/10931952694)
![Screenshot_20240919_022626_SCEE Dev](https://github.com/user-attachments/assets/e357564b-7f8c-43e9-a8ba-5cebf269ef33)



</details>