### PR TITLE
Fix : add navigation icon + title

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DataManagementSettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DataManagementSettingsFragment.kt
@@ -47,6 +47,7 @@ import de.westnordost.streetcomplete.quests.tree.FILENAME_TREES
 import de.westnordost.streetcomplete.screens.HasTitle
 import de.westnordost.streetcomplete.util.dialogs.setViewWithDefaultPadding
 import de.westnordost.streetcomplete.util.getFakeCustomOverlays
+import de.westnordost.streetcomplete.util.ktx.setUpToolbarTitleAndIcon
 import de.westnordost.streetcomplete.util.ktx.toast
 import de.westnordost.streetcomplete.util.logs.Log
 import kotlinx.coroutines.Dispatchers
@@ -78,7 +79,7 @@ class DataManagementSettingsFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         view.rootView.findViewById<Toolbar>(R.id.toolbar)?.apply {
-//            setUpToolbarTitleAndIcon(this)
+            setUpToolbarTitleAndIcon(this)
         }
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DisplaySettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DisplaySettingsFragment.kt
@@ -27,6 +27,7 @@ import de.westnordost.streetcomplete.data.osm.mapdata.LatLon
 import de.westnordost.streetcomplete.data.visiblequests.VisibleQuestTypeController
 import de.westnordost.streetcomplete.screens.HasTitle
 import de.westnordost.streetcomplete.util.dialogs.setViewWithDefaultPadding
+import de.westnordost.streetcomplete.util.ktx.setUpToolbarTitleAndIcon
 import de.westnordost.streetcomplete.util.ktx.toast
 import io.ticofab.androidgpxparser.parser.GPXParser
 import kotlinx.coroutines.GlobalScope
@@ -49,7 +50,7 @@ class DisplaySettingsFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         view.rootView.findViewById<Toolbar>(R.id.toolbar)?.apply {
-//            setUpToolbarTitleAndIcon(this)
+            setUpToolbarTitleAndIcon(this)
         }
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/NoteSettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/NoteSettingsFragment.kt
@@ -21,6 +21,7 @@ import de.westnordost.streetcomplete.data.osmnotes.notequests.getRawBlockList
 import de.westnordost.streetcomplete.data.preferences.Preferences
 import de.westnordost.streetcomplete.screens.HasTitle
 import de.westnordost.streetcomplete.util.dialogs.setDefaultDialogPadding
+import de.westnordost.streetcomplete.util.ktx.setUpToolbarTitleAndIcon
 import de.westnordost.streetcomplete.util.ktx.toast
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -40,7 +41,7 @@ class NoteSettingsFragment : PreferenceFragmentCompat(), HasTitle {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         view.rootView.findViewById<Toolbar>(R.id.toolbar)?.apply {
-//            setUpToolbarTitleAndIcon(this)
+            setUpToolbarTitleAndIcon(this)
         }
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/QuestsSettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/QuestsSettingsFragment.kt
@@ -33,6 +33,7 @@ import de.westnordost.streetcomplete.screens.HasTitle
 import de.westnordost.streetcomplete.util.dialogs.setViewWithDefaultPadding
 import de.westnordost.streetcomplete.util.ktx.dpToPx
 import de.westnordost.streetcomplete.util.ktx.hasPermission
+import de.westnordost.streetcomplete.util.ktx.setUpToolbarTitleAndIcon
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
@@ -53,7 +54,7 @@ class QuestsSettingsFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         view.rootView.findViewById<Toolbar>(R.id.toolbar)?.apply {
-//            setUpToolbarTitleAndIcon(this)
+            setUpToolbarTitleAndIcon(this)
         }
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/UiSettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/UiSettingsFragment.kt
@@ -13,6 +13,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.Toolbar
 import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
 import androidx.preference.DialogPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
@@ -22,6 +23,7 @@ import de.westnordost.streetcomplete.Prefs
 import de.westnordost.streetcomplete.R
 import de.westnordost.streetcomplete.screens.HasTitle
 import de.westnordost.streetcomplete.util.dialogs.setViewWithDefaultPadding
+import de.westnordost.streetcomplete.util.ktx.setUpToolbarTitleAndIcon
 import org.koin.android.ext.android.inject
 
 class UiSettingsFragment : PreferenceFragmentCompat(), HasTitle {
@@ -33,7 +35,7 @@ class UiSettingsFragment : PreferenceFragmentCompat(), HasTitle {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         view.rootView.findViewById<Toolbar>(R.id.toolbar)?.apply {
-//            setUpToolbarTitleAndIcon(this)
+            setUpToolbarTitleAndIcon(this)
         }
     }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/util/ktx/Fragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/util/ktx/Fragment.kt
@@ -1,10 +1,12 @@
 package de.westnordost.streetcomplete.util.ktx
 
+import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import de.westnordost.streetcomplete.screens.HasTitle
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
@@ -24,4 +26,23 @@ fun <T> Fragment.observe(flow: SharedFlow<T>, collector: FlowCollector<T>) {
             }
         }
     }
+}
+
+fun Fragment.setUpToolbarTitleAndIcon(toolbar: Toolbar) {
+    if (this is HasTitle) {
+        toolbar.title = title
+        toolbar.subtitle = subtitle
+    }
+
+    val typedArray =
+        toolbar.context.obtainStyledAttributes(intArrayOf(androidx.appcompat.R.attr.homeAsUpIndicator))
+    val attributeResourceId = typedArray.getResourceId(0, 0)
+    val backIcon = toolbar.context.getDrawable(attributeResourceId)
+    typedArray.recycle()
+
+    toolbar.setNavigationOnClickListener {
+        requireActivity().onBackPressedDispatcher.onBackPressed()
+    }
+
+    toolbar.navigationIcon = backIcon
 }

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -93,7 +93,7 @@
     </style>
 
     <style name="Toolbar.Button.Navigation.Tinted" parent="Widget.AppCompat.Toolbar.Button.Navigation">
-        <item name="tint">?attr/colorControlNormal</item>
+        <item name="tint">@android:color/white</item>
     </style>
 
 </resources>

--- a/app/src/main/res/xml/preferences_ee_data_management.xml
+++ b/app/src/main/res/xml/preferences_ee_data_management.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="auto_download"
         android:title="@string/pref_auto_download_title"
         android:summary="@string/pref_auto_download_summary"
@@ -10,6 +11,7 @@
         android:persistent="true" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="manual_download_override_cache"
         android:title="@string/pref_manual_download_cache_title"
         android:summary="@string/pref_manual_download_cache_summary"
@@ -17,10 +19,12 @@
         android:persistent="true" />
 
     <Preference
+        app:iconSpaceReserved="false"
         android:key="raster_tile_url"
         android:title="@string/pref_tile_source_title" />
 
     <de.westnordost.streetcomplete.screens.settings.NumberPickerPreference
+        app:iconSpaceReserved="false"
         android:key="data_retain_time"
         android:title="@string/pref_delete_old_data_after"
         android:summary="@string/pref_delete_old_data_after_summary"
@@ -35,6 +39,7 @@
         android:negativeButtonText="@android:string/cancel" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="update_local_statistics"
         android:title="@string/pref_update_local_statistics"
         android:summary="@string/pref_update_local_statistics_summary"
@@ -42,6 +47,7 @@
         android:persistent="true" />
 
     <de.westnordost.streetcomplete.screens.settings.NumberPickerPreference
+        app:iconSpaceReserved="false"
         android:key="gps_interval"
         android:title="@string/pref_gps_interval_title"
         android:summary="@string/pref_interval_summary"
@@ -56,6 +62,7 @@
         android:negativeButtonText="@android:string/cancel" />
 
     <de.westnordost.streetcomplete.screens.settings.NumberPickerPreference
+        app:iconSpaceReserved="false"
         android:key="network_interval"
         android:title="@string/pref_network_interval_title"
         android:summary="@string/pref_interval_summary"
@@ -70,20 +77,24 @@
         android:negativeButtonText="@android:string/cancel" />
 
     <Preference
+        app:iconSpaceReserved="false"
         android:key="trees"
         android:title="@string/pref_trees_title"
         android:summary="@string/pref_tree_custom_quest_summary" />
 
     <Preference
+        app:iconSpaceReserved="false"
         android:key="custom_quest"
         android:title="@string/pref_custom_title"
         android:summary="@string/pref_tree_custom_quest_summary" />
 
     <Preference
+        app:iconSpaceReserved="false"
         android:key="export"
         android:title="@string/pref_export" />
 
     <Preference
+        app:iconSpaceReserved="false"
         android:key="import"
         android:title="@string/pref_import" />
 

--- a/app/src/main/res/xml/preferences_ee_display.xml
+++ b/app/src/main/res/xml/preferences_ee_display.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 <!-- not possible with mapLibre
     <SwitchPreference
         android:key="3d_buildings"
@@ -8,6 +9,7 @@
         android:persistent="true" />
 -->
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="show_way_direction"
         android:title="@string/pref_way_direction"
         android:summary="@string/pref_way_direction_summary"
@@ -15,6 +17,7 @@
         android:persistent="true" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="quest_geometries"
         android:title="@string/pref_quest_geometries_title"
         android:summary="@string/pref_quest_geometries_summary"
@@ -22,6 +25,7 @@
         android:persistent="true" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="offset_fix"
         android:title="@string/pref_offset_fix_title2"
         android:summary="@string/pref_offset_fix_summary"
@@ -29,6 +33,7 @@
         android:persistent="true" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="show_solved_animation"
         android:title="@string/pref_show_solved_animation"
         android:summary="@string/pref_show_solved_animation_summary"
@@ -36,6 +41,7 @@
         android:persistent="true" />
 
     <Preference
+        app:iconSpaceReserved="false"
         android:key="display_gpx_track"
         android:title="@string/pref_gpx_track_title" />
 

--- a/app/src/main/res/xml/preferences_ee_notes.xml
+++ b/app/src/main/res/xml/preferences_ee_notes.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="gpx_button"
         android:title="@string/pref_show_gpx_button_title"
         android:summary="@string/pref_show_gpx_button_summary"
@@ -9,12 +11,14 @@
         android:persistent="true" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="swap_gpx_note_buttons"
         android:title="@string/pref_swap_gpx_note_button"
         android:defaultValue="false"
         android:persistent="true" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="hide_keyboard_for_note"
         android:title="@string/pref_hide_keyboard_title"
         android:summary="@string/pref_hide_keyboard_summary"
@@ -22,6 +26,7 @@
         android:persistent="true" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="create_external_quests"
         android:title="@string/pref_create_custom_quest_title"
         android:summary="@string/pref_create_custom_quest_summary"
@@ -29,6 +34,7 @@
         android:persistent="true" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="save_photos"
         android:title="@string/pref_save_photos_title"
         android:summary="@string/pref_save_photos_summary"
@@ -36,14 +42,17 @@
         android:persistent="true" />
 
     <Preference
+        app:iconSpaceReserved="false"
         android:key="hide_notes_by2"
         android:title="@string/pref_hide_notes_title" />
 
     <Preference
+        app:iconSpaceReserved="false"
         android:key="get_gpx_notes"
         android:title="@string/pref_save_gpx" />
 
     <Preference
+        app:iconSpaceReserved="false"
         android:key="get_photos"
         android:title="@string/pref_get_photos_title" />
 

--- a/app/src/main/res/xml/preferences_ee_quests.xml
+++ b/app/src/main/res/xml/preferences_ee_quests.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <ListPreference
+        app:iconSpaceReserved="false"
         android:key="day_night_behavior"
         android:title="@string/pref_day_night_title"
         app:useSimpleSummaryProvider="true"
@@ -12,11 +13,13 @@
         android:persistent="true" />
 
     <Preference
+        app:iconSpaceReserved="false"
         android:key="advanced_resurvey"
         android:title="@string/pref_advanced_resurvey_title"
         android:summary="@string/pref_advanced_resurvey_summary" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="quest_settings_per_preset"
         android:title="@string/pref_quest_settings_preset_title"
         android:summary="@string/pref_quest_settings_preset_summary"
@@ -24,6 +27,7 @@
         android:persistent="true" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="dynamic_quest_creation"
         android:title="@string/pref_dynamic_quest_creation_title"
         android:summary="@string/pref_dynamic_quest_creation_summary"
@@ -31,11 +35,13 @@
         android:persistent="true" />
 
     <Preference
+        app:iconSpaceReserved="false"
         android:key="quest_monitor"
         android:title="@string/pref_quest_monitor_title"
         android:summary="@string/pref_quest_monitor_summary" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="hide_overlay_quests"
         android:title="@string/pref_hide_overlay_quests"
         android:defaultValue="true"

--- a/app/src/main/res/xml/preferences_ee_ui.xml
+++ b/app/src/main/res/xml/preferences_ee_ui.xml
@@ -3,18 +3,21 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="quick_settings"
         android:title="@string/pref_show_quick_settings_title"
         android:defaultValue="false"
         android:persistent="true" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="overlay_quick_selector"
         android:title="@string/pref_overlay_quick_selector_title"
         android:defaultValue="false"
         android:persistent="true" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="show_next_quest_immediately"
         android:title="@string/pref_show_next_quest_title"
         android:summary="@string/pref_show_next_quest_summary"
@@ -22,11 +25,13 @@
         android:persistent="true" />
 
     <Preference
+        app:iconSpaceReserved="false"
         android:key="show_nearby_quests"
         android:title="@string/pref_show_nearby_quests_title"
         android:summary="@string/pref_show_nearby_quests_summary" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="show_hide_button"
         android:title="@string/pref_hide_button_title"
         android:summary="@string/pref_hide_button_summary"
@@ -34,12 +39,14 @@
         android:persistent="true" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="create_node_show_keyboard"
         android:title="@string/pref_create_node_show_keyboard_title"
         android:defaultValue="true"
         android:persistent="true" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="select_first_edit"
         android:title="@string/pref_select_first_edit_title"
         android:summary="@string/pref_select_first_edit_summary"
@@ -47,6 +54,7 @@
         android:persistent="true" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="search_more_languages"
         android:title="@string/pref_search_more_languages_title"
         android:summary="@string/pref_search_more_languages_summary"
@@ -54,6 +62,7 @@
         android:persistent="true" />
 
     <de.westnordost.streetcomplete.screens.settings.NumberPickerPreference
+        app:iconSpaceReserved="false"
         android:key="favs_first_min_lines"
         android:title="@string/pref_recent_answers_first_min_lines"
         android:summary="@string/pref_recent_answers_first_min_lines_summary"
@@ -68,6 +77,7 @@
         android:negativeButtonText="@android:string/cancel" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="disable_navigation_mode"
         android:title="@string/pref_disable_navigation_mode_title"
         android:summary="@string/pref_disable_navigation_mode_summary"
@@ -75,24 +85,28 @@
         android:persistent="true" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="main_menu_full_grid"
         android:title="@string/pref_main_menu_grid"
         android:defaultValue="false"
         android:persistent="true" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="main_menu_switch_presets"
         android:title="@string/pref_main_menu_switch_presets_title"
         android:defaultValue="false"
         android:persistent="true" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="caps_word_name_input"
         android:title="@string/pref_caps_word_name_input"
         android:defaultValue="false"
         android:persistent="true" />
 
     <SwitchPreference
+        app:iconSpaceReserved="false"
         android:key="volume_button_zoom"
         android:title="@string/pref_volume_zoom_title"
         android:summary="@string/pref_volume_zoom_summary"


### PR DESCRIPTION
I noticed a difference between the SC and SCEE screens.
It's missing : 
the navigation icon
the title

By the way, I've removed the unnecessary spacing provided by PreferenceScreen.

![Screenshot_20240929_074152](https://github.com/user-attachments/assets/52b018dd-480f-45e8-a3fe-5e8d73dc8dcc)
