### PR TITLE
Add lamp type quest

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/QuestsModule.kt
@@ -114,6 +114,7 @@ import de.westnordost.streetcomplete.quests.incline_direction.AddBicycleIncline
 import de.westnordost.streetcomplete.quests.incline_direction.AddStepsIncline
 import de.westnordost.streetcomplete.quests.internet_access.AddInternetAccess
 import de.westnordost.streetcomplete.quests.kerb_height.AddKerbHeight
+import de.westnordost.streetcomplete.quests.lamp_type.AddLampType
 import de.westnordost.streetcomplete.quests.lanes.AddLanes
 import de.westnordost.streetcomplete.quests.leaf_detail.AddForestLeafType
 import de.westnordost.streetcomplete.quests.leaf_detail.AddTreeLeafType
@@ -637,6 +638,7 @@ fun getQuestTypeList(
     EE_QUEST_OFFSET + 50 to AddCaravanSiteType(),
     EE_QUEST_OFFSET + 52 to AddSaunaAvailability(),
     EE_QUEST_OFFSET + 53 to AddSwimmingPoolAvailability(),
+    EE_QUEST_OFFSET + 54 to AddLampType(),
     EE_QUEST_OFFSET + 10 to OsmoseQuest(osmoseDao),
     EE_QUEST_OFFSET + 11 to CustomQuest(customQuestList),
     // POI quests

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/lamp_type/AddLampType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/lamp_type/AddLampType.kt
@@ -1,0 +1,39 @@
+package de.westnordost.streetcomplete.quests.lamp_type
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.filter
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
+import de.westnordost.streetcomplete.data.user.achievements.EditTypeAchievement
+import de.westnordost.streetcomplete.osm.Tags
+import de.westnordost.streetcomplete.osm.isPlace
+import de.westnordost.streetcomplete.quests.seating.AddOutdoorSeatingTypeForm
+
+class AddLampType : OsmFilterQuestType<String>() {
+
+    override val elementFilter = """
+        nodes with
+          highway = street_lamp
+          and !lamp_type
+          and !light:method
+    """
+    override val changesetComment = "Add lamp type"
+    override val defaultDisabledMessage = R.string.quest_lampType_disabled_msg
+    override val wikiLink = "Key:lamp_type"
+    override val icon = R.drawable.ic_quest_lamp_type
+    override val isReplacePlaceEnabled = true
+    override val achievements = listOf(EditTypeAchievement.CITIZEN)
+
+    override fun getTitle(tags: Map<String, String>) = R.string.quest_lampType_title
+
+    override fun getHighlightedElements(element: Element, getMapData: () -> MapDataWithGeometry) =
+        getMapData().filter("nodes with highway = street_lamp")
+
+    override fun createForm() = AddLampTypeForm()
+
+    override fun applyAnswerTo(answer: String, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
+        tags["lamp_type"] = answer
+    }
+}

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/lamp_type/AddLampTypeForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/lamp_type/AddLampTypeForm.kt
@@ -1,0 +1,19 @@
+package de.westnordost.streetcomplete.quests.lamp_type
+
+import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.quests.AListQuestForm
+import de.westnordost.streetcomplete.quests.TextItem
+
+class AddLampTypeForm : AListQuestForm<String>() {
+    override val items = listOf(
+        TextItem("led", R.string.quest_lampType_led),
+        TextItem("high_pressure_sodium", R.string.quest_lampType_highPressureSodium),
+        TextItem("low_pressure_sodium", R.string.quest_lampType_lowPressureSodium),
+        TextItem("gaslight", R.string.quest_lampType_gaslight),
+        TextItem("fluorescent", R.string.quest_lampType_fluorescent),
+        TextItem("incandescent", R.string.quest_lampType_incandescent),
+        TextItem("metal-halide", R.string.quest_lampType_metalHalide),
+        TextItem("mercury", R.string.quest_lampType_mercury),
+        TextItem("halogen", R.string.quest_lampType_halogen),
+    )
+}

--- a/app/src/main/res/drawable/ic_quest_lamp_type.xml
+++ b/app/src/main/res/drawable/ic_quest_lamp_type.xml
@@ -1,0 +1,40 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="128dp"
+    android:viewportWidth="128"
+    android:viewportHeight="128">
+  <path
+      android:pathData="m128,64c0,35.35 -28.65,64 -64,64 -35.35,0 -64,-28.65 -64,-64s28.65,-64 64,-64c35.35,0 64,28.65 64,64"
+      android:strokeWidth=".2"
+      android:fillColor="#aaa"/>
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="m48,93.38v8l10,4h12l10,-4v-8z"
+      android:strokeWidth=".2"
+      android:fillAlpha="0.2"/>
+  <path
+      android:pathData="m6.12,36.68c-3.92,8.29 -6.12,17.55 -6.12,27.32 0,15.65 5.63,29.98 14.95,41.1l37.05,-17.1h24l37.05,17.1c9.33,-11.12 14.95,-25.45 14.95,-41.1 0,-9.77 -2.2,-19.03 -6.12,-27.32l-29.88,3.32h-56z"
+      android:strokeWidth=".2"
+      android:fillColor="#ffffdf"
+      android:fillAlpha="0.53333"/>
+  <path
+      android:pathData="m40,40 l8,48h32l8,-48z"
+      android:strokeWidth="4"
+      android:fillColor="#ffffdf"
+      android:fillType="evenOdd"
+      android:strokeColor="#c1a551"/>
+  <path
+      android:pathData="m52,40 l4,48"
+      android:strokeWidth="4"
+      android:fillColor="#00000000"
+      android:strokeColor="#c1a551"/>
+  <path
+      android:pathData="m76,40 l-4,48"
+      android:strokeWidth="4"
+      android:fillColor="#00000000"
+      android:strokeColor="#c1a551"/>
+  <path
+      android:pathData="m64,12c-12,4 -20,20 -32,20v8h64v-8c-12,0 -20,-16 -32,-20zM48,88v8l10,4v27.71c1.98,0.18 3.98,0.29 6,0.29s4.02,-0.11 6,-0.29v-27.71l10,-4v-8z"
+      android:fillColor="#555"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/values/strings_ee.xml
+++ b/app/src/main/res/values/strings_ee.xml
@@ -653,6 +653,19 @@
     <string name="quest_sacScale_six">"T6 - difficult alpine hiking"</string>
     <string name="quest_sacScale_six_description">"Severe exposure. Difficult craggy terrain. Glaciers with high risk of sliding."</string>
 
+    <!-- lamp type -->
+    <string name="quest_lampType_title">What kind of lamp is this?</string>
+    <string name="quest_lampType_disabled_msg">This quest is disabled by default because it’s not easy to answer and might be spammy depending on the region.</string>
+    <string name="quest_lampType_led">LED lamp</string>
+    <string name="quest_lampType_highPressureSodium">High-pressure sodium lamp</string>
+    <string name="quest_lampType_lowPressureSodium">Low-pressure sodium lamp</string>
+    <string name="quest_lampType_gaslight">Gaslight</string>
+    <string name="quest_lampType_fluorescent">Fluorescent lamp</string>
+    <string name="quest_lampType_incandescent">Incandescent lamp</string>
+    <string name="quest_lampType_metalHalide">Metal-halide lamp</string>
+    <string name="quest_lampType_mercury">Mercury-vapor lamp</string>
+    <string name="quest_lampType_halogen">Halogen lamp</string>
+
     <!-- new overlays -->
 
     <!-- custom overlay -->

--- a/res/graphics/quest/lamp_type.svg
+++ b/res/graphics/quest/lamp_type.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+ <path d="m128 64c0 35.346-28.654 64-64 64-35.346 0-64-28.654-64-64s28.654-64 64-64c35.346 0 64 28.654 64 64" fill="#aaa" stroke-width=".2"/>
+ <path d="m48 93.375v8l10 4h12l10-4v-8z" fill-opacity=".2" stroke-width=".2"/>
+ <path d="m6.1172 36.68c-3.9184 8.2868-6.1172 17.545-6.1172 27.32 0 15.65 5.6252 29.98 14.953 41.1l37.047-17.1h24l37.047 17.1c9.328-11.12 14.953-25.45 14.953-41.1 0-9.775-2.1988-19.033-6.1172-27.32l-29.883 3.3203h-56z" fill="#ffffdf" fill-opacity=".53333" stroke-width=".2"/>
+ <path d="m40 40 8 48h32l8-48z" fill="#ffffdf" fill-rule="evenodd" stroke="#c1a551" stroke-width="4"/>
+ <path d="m52 40 4 48" fill="none" stroke="#c1a551" stroke-width="4"/>
+ <path d="m76 40-4 48" fill="none" stroke="#c1a551" stroke-width="4"/>
+ <path d="m64 12c-12 4-20 20-32 20v8h64v-8c-12 0-20-16-32-20zm-16 76v8l10 4v27.711c1.9766 0.18389 3.9754 0.28906 6 0.28906s4.0234-0.10517 6-0.28906v-27.711l10-4v-8z" fill="#555" fill-rule="evenodd"/>
+</svg>


### PR DESCRIPTION
Adds [`lamp_type`](https://wiki.openstreetmap.org/wiki/Key:lamp_type) to `highway = street_lamp`. I didn't suggest this quest in upstream StreetComplete because it probably does not pass the quest guidelines:

- 🚧 To be added tag is established and has a useful purpose
  - It is [widely in use](https://taginfo.openstreetmap.org/keys/lamp_type) (> 1M)
  - There is a [less popular but similar competing tag](https://wiki.openstreetmap.org/wiki/Key:lamp_type#See_Also)
  - It is used for rendering in https://sb12.github.io/OSMStreetLight/ (but that probably is not enough to be useful enough for upstream StreetComplete)
- 🤔 Any answer the user can give must have an equivalent tagging (Quest should not reappear to other users when solved by one)
  - Yes
- 🐿️ Easily answerable by any pedestrian from the outside but a survey is necessary
  - Not always easy to answer
  - Survey is necessary
- 💤 Not an overwhelming percentage of quests have the same answer (No spam)
  - Depends on the region
- 🕓 Applies to a reasonable number of map data (Worth the effort)
  - Yes, as there are [more than 4M street lamps](https://taginfo.openstreetmap.org/tags/highway=street_lamp#overview)

But I wanted to use it anyway and thought, maybe it is good enough for inclusion in SCEE.

### See also

* Similar upstream quest suggestion: https://github.com/streetcomplete/StreetComplete/issues/5647