### PR TITLE
Reference quest names via `::class.simpleName!!`

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/StreetCompleteApplication.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/StreetCompleteApplication.kt
@@ -59,7 +59,7 @@ import de.westnordost.streetcomplete.screens.about.aboutScreenModule
 import de.westnordost.streetcomplete.screens.main.mainModule
 import de.westnordost.streetcomplete.screens.measure.arModule
 import de.westnordost.streetcomplete.screens.settings.LAST_KNOWN_DB_VERSION
-import de.westnordost.streetcomplete.screens.settings.oldQuestNames
+import de.westnordost.streetcomplete.screens.settings.renamedQuests
 import de.westnordost.streetcomplete.screens.settings.renameUpdatedQuests
 import de.westnordost.streetcomplete.screens.settings.settingsModule
 import de.westnordost.streetcomplete.screens.user.userScreenModule
@@ -190,7 +190,7 @@ class StreetCompleteApplication : Application() {
             // update prefs referring to renamed quests
             val prefsToRename = preferences.all.filter { pref ->
                 val v = pref.value
-                oldQuestNames.any { pref.key.contains(it) || (v is String && v.contains(it)) }
+                renamedQuests.keys.any { pref.key.contains(it) || (v is String && v.contains(it)) }
             }
             val e = preferences.edit()
             prefsToRename.forEach {

--- a/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestController.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/data/osm/osmquests/OsmQuestController.kt
@@ -22,9 +22,20 @@ import de.westnordost.streetcomplete.data.quest.OsmQuestKey
 import de.westnordost.streetcomplete.data.quest.QuestType
 import de.westnordost.streetcomplete.data.quest.QuestTypeRegistry
 import de.westnordost.streetcomplete.quests.address.AddHousenumber
+import de.westnordost.streetcomplete.quests.barrier_type.AddBarrierOnPath
+import de.westnordost.streetcomplete.quests.barrier_type.AddBarrierOnRoad
+import de.westnordost.streetcomplete.quests.building_entrance.AddEntrance
+import de.westnordost.streetcomplete.quests.building_entrance_reference.AddEntranceReference
+import de.westnordost.streetcomplete.quests.crossing.AddCrossing
 import de.westnordost.streetcomplete.quests.cycleway.AddCycleway
+import de.westnordost.streetcomplete.quests.destination.AddDestination
 import de.westnordost.streetcomplete.quests.existence.CheckExistence
+import de.westnordost.streetcomplete.quests.kerb_height.AddKerbHeight
+import de.westnordost.streetcomplete.quests.max_height.AddMaxHeight
 import de.westnordost.streetcomplete.quests.opening_hours.AddOpeningHours
+import de.westnordost.streetcomplete.quests.piste_difficulty.AddPisteDifficulty
+import de.westnordost.streetcomplete.quests.piste_lit.AddPisteLit
+import de.westnordost.streetcomplete.quests.piste_ref.AddPisteRef
 import de.westnordost.streetcomplete.quests.place_name.AddPlaceName
 import de.westnordost.streetcomplete.util.Listeners
 import de.westnordost.streetcomplete.util.ktx.format
@@ -78,11 +89,21 @@ class OsmQuestController internal constructor(
             .map { it.name }.toHashSet()
     }
 
-    // must be valid names!
-    // todo: use actual class names, or better re-evaluate whether this is worth it and maybe invert to blacklist
-    private val questsRequiringElementsWithoutTags = hashSetOf("AddBarrierOnRoad", "AddBarrierOnPath", "AddCrossing",
-        "AddMaxHeight", "AddEntrance", "AddEntranceReference", "AddHousenumber", "AddDestination", "AddPisteDifficulty",
-        "AddKerbHeight", "AddPisteRef", "AddPisteLit")
+    // todo: re-evaluate whether this is worth it and maybe invert to blacklist
+    private val questsRequiringElementsWithoutTags = hashSetOf(
+        AddBarrierOnRoad::class.simpleName!!,
+        AddBarrierOnPath::class.simpleName!!,
+        AddCrossing::class.simpleName!!,
+        AddMaxHeight::class.simpleName!!,
+        AddEntrance::class.simpleName!!,
+        AddEntranceReference::class.simpleName!!,
+        AddHousenumber::class.simpleName!!,
+        AddDestination::class.simpleName!!,
+        AddPisteDifficulty::class.simpleName!!,
+        AddKerbHeight::class.simpleName!!,
+        AddPisteRef::class.simpleName!!,
+        AddPisteLit::class.simpleName!!,
+    )
 
     private val hiddenCache by lazy { synchronized(this) { hiddenDB.getAllIds().toHashSet() } }
 

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DataManagementSettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DataManagementSettingsFragment.kt
@@ -753,9 +753,12 @@ class DataManagementSettingsFragment :
 // when importing, names should be updated!
 private fun List<String>.renameUpdatedQuests() = map { it.renameUpdatedQuests() }
 
-fun String.renameUpdatedQuests() = replace("ExternalQuest", CustomQuest::class.simpleName!!)
-    .replace("AddPicnicTableCover", AddAmenityCover::class.simpleName!!)
-val oldQuestNames = listOf("ExternalQuest", "AddPicnicTableCover")
+val renamedQuests = mapOf(
+    "ExternalQuest" to CustomQuest::class.simpleName!!,
+    "AddPicnicTableCover" to AddAmenityCover::class.simpleName!!,
+)
+fun String.renameUpdatedQuests() =
+    renamedQuests.entries.fold(this) { acc, (old, new) -> acc.replace(old, new) }
 
 private const val REQUEST_CODE_SETTINGS_EXPORT = 532527
 private const val REQUEST_CODE_HIDDEN_EXPORT = 532528

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DataManagementSettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DataManagementSettingsFragment.kt
@@ -43,6 +43,8 @@ import de.westnordost.streetcomplete.data.visiblequests.VisibleQuestTypeControll
 import de.westnordost.streetcomplete.data.visiblequests.VisibleQuestTypeTable
 import de.westnordost.streetcomplete.overlays.custom.getCustomOverlayIndices
 import de.westnordost.streetcomplete.overlays.custom.getIndexedCustomOverlayPref
+import de.westnordost.streetcomplete.quests.amenity_cover.AddAmenityCover
+import de.westnordost.streetcomplete.quests.custom.CustomQuest
 import de.westnordost.streetcomplete.quests.custom.FILENAME_CUSTOM_QUEST
 import de.westnordost.streetcomplete.quests.osmose.OsmoseDao
 import de.westnordost.streetcomplete.quests.tree.FILENAME_TREES
@@ -751,8 +753,8 @@ class DataManagementSettingsFragment :
 // when importing, names should be updated!
 private fun List<String>.renameUpdatedQuests() = map { it.renameUpdatedQuests() }
 
-fun String.renameUpdatedQuests() = replace("ExternalQuest", "CustomQuest")
-    .replace("AddPicnicTableCover", "AddAmenityCover")
+fun String.renameUpdatedQuests() = replace("ExternalQuest", CustomQuest::class.simpleName!!)
+    .replace("AddPicnicTableCover", AddAmenityCover::class.simpleName!!)
 val oldQuestNames = listOf("ExternalQuest", "AddPicnicTableCover")
 
 private const val REQUEST_CODE_SETTINGS_EXPORT = 532527


### PR DESCRIPTION
see https://github.com/Helium314/SCEE/pull/716#discussion_r1906828628:

After `AddBarrierOnRoad` is imported, `AddBarrierOnRoad::class.simpleName!!` will be replaced at runtime with the string `"AddBarrierOnRoad"`, so there is basically no runtime change.

But (and this is the advantage) when the `AddBarrierOnRoad` class is renamed or removed, `AddBarrierOnRoad::class.simpleName!!` will throw an error at compile time if it is not updated accordingly, so it can't be forgotten, while a simple string value `"AddBarrierOnRoad"` can be.
