### PR TITLE
SCEE Automatic maxzoom for default Arcgisonline URL

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/ApplicationConstants.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/ApplicationConstants.kt
@@ -35,6 +35,7 @@ object ApplicationConstants {
 
     /** default maximum zoom for satellite imagery */
     const val RASTER_DEFAULT_MAXZOOM = 21
+    const val RASTER_DEFAULT_URL = "https://server.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}?blankTile=false"
 
     /** when new quests that are appearing due to download of an area, show the hint that he can
      *  disable quests in the settings if more than X quests did appear */

--- a/app/src/main/java/de/westnordost/streetcomplete/ApplicationConstants.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/ApplicationConstants.kt
@@ -34,7 +34,7 @@ object ApplicationConstants {
     const val NOTE_MIN_ZOOM = 15
 
     /** default maximum zoom for satellite imagery */
-    const val RASTER_DEFAULT_MAXZOOM = 18
+    const val RASTER_DEFAULT_MAXZOOM = 21
 
     /** when new quests that are appearing due to download of an area, show the hint that he can
      *  disable quests in the settings if more than X quests did appear */

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/SceneMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/SceneMapComponent.kt
@@ -54,7 +54,7 @@ class SceneMapComponent(
         }
         val styleJsonString = when {
             prefs.prefs.getString(Prefs.THEME_BACKGROUND, "MAP") != "MAP" ->
-                createMapStyle("StreetComplete-Raster", token, emptyList(), rasterBackground(prefs.prefs.getBoolean(Prefs.NO_SATELLITE_LABEL, false)), prefs.prefs.getString(Prefs.RASTER_TILE_URL, RASTER_DEFAULT_URL), prefs.prefs.getInt(Prefs.RASTER_TILE_MAXZOOM, ApplicationConstants.RASTER_DEFAULT_MAXZOOM))
+                createMapStyle("StreetComplete-Raster", token, emptyList(), rasterBackground(prefs.prefs.getBoolean(Prefs.NO_SATELLITE_LABEL, false)), prefs.prefs.getString(Prefs.RASTER_TILE_URL, ApplicationConstants.RASTER_DEFAULT_URL), prefs.prefs.getInt(Prefs.RASTER_TILE_MAXZOOM, ApplicationConstants.RASTER_DEFAULT_MAXZOOM))
             prefs.theme == Theme.DARK_CONTRAST -> createMapStyle("StreetComplete-Dark_Contrast", token, emptyList(), themeDarkContrast)
             isNightMode -> context.resources.assets.open("map_theme/streetcomplete-night.json").bufferedReader().use { it.readText() }
             else -> context.resources.assets.open("map_theme/streetcomplete.json").bufferedReader().use { it.readText() }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/SceneMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/SceneMapComponent.kt
@@ -54,7 +54,7 @@ class SceneMapComponent(
         }
         val styleJsonString = when {
             prefs.prefs.getString(Prefs.THEME_BACKGROUND, "MAP") != "MAP" ->
-                createMapStyle("StreetComplete-Raster", token, emptyList(), rasterBackground(prefs.prefs.getBoolean(Prefs.NO_SATELLITE_LABEL, false)), prefs.prefs.getString(Prefs.RASTER_TILE_URL, "https://server.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}?blankTile=false"), prefs.prefs.getInt(Prefs.RASTER_TILE_MAXZOOM, ApplicationConstants.RASTER_DEFAULT_MAXZOOM))
+                createMapStyle("StreetComplete-Raster", token, emptyList(), rasterBackground(prefs.prefs.getBoolean(Prefs.NO_SATELLITE_LABEL, false)), prefs.prefs.getString(Prefs.RASTER_TILE_URL, RASTER_DEFAULT_URL), prefs.prefs.getInt(Prefs.RASTER_TILE_MAXZOOM, ApplicationConstants.RASTER_DEFAULT_MAXZOOM))
             prefs.theme == Theme.DARK_CONTRAST -> createMapStyle("StreetComplete-Dark_Contrast", token, emptyList(), themeDarkContrast)
             isNightMode -> context.resources.assets.open("map_theme/streetcomplete-night.json").bufferedReader().use { it.readText() }
             else -> context.resources.assets.open("map_theme/streetcomplete.json").bufferedReader().use { it.readText() }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/SceneMapComponent.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/components/SceneMapComponent.kt
@@ -54,7 +54,7 @@ class SceneMapComponent(
         }
         val styleJsonString = when {
             prefs.prefs.getString(Prefs.THEME_BACKGROUND, "MAP") != "MAP" ->
-                createMapStyle("StreetComplete-Raster", token, emptyList(), rasterBackground(prefs.prefs.getBoolean(Prefs.NO_SATELLITE_LABEL, false)), prefs.prefs.getString(Prefs.RASTER_TILE_URL, "https://server.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"), prefs.prefs.getInt(Prefs.RASTER_TILE_MAXZOOM, ApplicationConstants.RASTER_DEFAULT_MAXZOOM))
+                createMapStyle("StreetComplete-Raster", token, emptyList(), rasterBackground(prefs.prefs.getBoolean(Prefs.NO_SATELLITE_LABEL, false)), prefs.prefs.getString(Prefs.RASTER_TILE_URL, "https://server.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}?blankTile=false"), prefs.prefs.getInt(Prefs.RASTER_TILE_MAXZOOM, ApplicationConstants.RASTER_DEFAULT_MAXZOOM))
             prefs.theme == Theme.DARK_CONTRAST -> createMapStyle("StreetComplete-Dark_Contrast", token, emptyList(), themeDarkContrast)
             isNightMode -> context.resources.assets.open("map_theme/streetcomplete-night.json").bufferedReader().use { it.readText() }
             else -> context.resources.assets.open("map_theme/streetcomplete.json").bufferedReader().use { it.readText() }

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DataManagementSettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DataManagementSettingsFragment.kt
@@ -147,7 +147,7 @@ class DataManagementSettingsFragment :
 
         findPreference<Preference>("raster_tile_url")?.setOnPreferenceClickListener {
             var d: AlertDialog? = null
-            val currentUrl = prefs.getString(Prefs.RASTER_TILE_URL, RASTER_DEFAULT_URL)!!
+            val currentUrl = prefs.getString(Prefs.RASTER_TILE_URL, ApplicationConstants.RASTER_DEFAULT_URL)!!
             val urlText = EditText(requireContext()).apply {
                 setText(currentUrl)
                 doAfterTextChanged {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DataManagementSettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DataManagementSettingsFragment.kt
@@ -147,7 +147,7 @@ class DataManagementSettingsFragment :
 
         findPreference<Preference>("raster_tile_url")?.setOnPreferenceClickListener {
             var d: AlertDialog? = null
-            val currentUrl = prefs.getString(Prefs.RASTER_TILE_URL, "https://server.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}?blankTile=false")!!
+            val currentUrl = prefs.getString(Prefs.RASTER_TILE_URL, RASTER_DEFAULT_URL)!!
             val urlText = EditText(requireContext()).apply {
                 setText(currentUrl)
                 doAfterTextChanged {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DataManagementSettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/DataManagementSettingsFragment.kt
@@ -147,7 +147,7 @@ class DataManagementSettingsFragment :
 
         findPreference<Preference>("raster_tile_url")?.setOnPreferenceClickListener {
             var d: AlertDialog? = null
-            val currentUrl = prefs.getString(Prefs.RASTER_TILE_URL, "https://server.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}")!!
+            val currentUrl = prefs.getString(Prefs.RASTER_TILE_URL, "https://server.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}?blankTile=false")!!
             val urlText = EditText(requireContext()).apply {
                 setText(currentUrl)
                 doAfterTextChanged {


### PR DESCRIPTION
Fixes https://github.com/Helium314/SCEE/issues/724

It looks that Arcgisonline (which we use for satellite imagery) has an option `?blankTile=false` which returns HTTP `404` instead of fake tiles, which MapLibre handles and does software zoom instead. That allows us to use maximum existing zoom (or even higher :smile:, but no point), and get the best quality without any bad side-effects.

Thanks to @rusty-snake for finding this option! 

(tested in https://github.com/mnalis/StreetComplete/actions/runs/12835908401)