### PR TITLE
Add ROTATE_WHILE_ZOOMING + ROTATE_ANGLE_THRESHOLD MapLibre tunables (in UI Settings screen)

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/ApplicationConstants.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/ApplicationConstants.kt
@@ -37,8 +37,6 @@ object ApplicationConstants {
     const val RASTER_DEFAULT_MAXZOOM = 21
     const val RASTER_DEFAULT_URL = "https://server.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}?blankTile=false"
 
-    const val ROTATE_ANGLE_THRESHOLD_DEFAULT = 1.5f
-
     /** when new quests that are appearing due to download of an area, show the hint that he can
      *  disable quests in the settings if more than X quests did appear */
     const val QUEST_COUNT_AT_WHICH_TO_SHOW_QUEST_SELECTION_HINT = 600

--- a/app/src/main/java/de/westnordost/streetcomplete/ApplicationConstants.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/ApplicationConstants.kt
@@ -37,6 +37,8 @@ object ApplicationConstants {
     const val RASTER_DEFAULT_MAXZOOM = 21
     const val RASTER_DEFAULT_URL = "https://server.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}?blankTile=false"
 
+    const val ROTATE_ANGLE_THRESHOLD_DEFAULT = 1.5f
+
     /** when new quests that are appearing due to download of an area, show the hint that he can
      *  disable quests in the settings if more than X quests did appear */
     const val QUEST_COUNT_AT_WHICH_TO_SHOW_QUEST_SELECTION_HINT = 600

--- a/app/src/main/java/de/westnordost/streetcomplete/Prefs.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/Prefs.kt
@@ -68,6 +68,8 @@ object Prefs {
     const val SHOW_CUSTOM_GEOMETRY = "show_custom_geometry"
     const val THEME_BACKGROUND = "theme.background_type"
     const val REALLY_ALL_NOTES = "really_all_notes"
+    const val ROTATE_WHILE_ZOOMING = "rotate_while_zooming"
+    const val ROTATE_ANGLE_THRESHOLD = "rotate_angle_threshold"
 
     enum class DayNightBehavior {
         IGNORE,

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
@@ -161,7 +161,7 @@ open class MapFragment : Fragment(R.layout.fragment_map) {
         map.uiSettings.isLogoEnabled = false
         map.uiSettings.flingThreshold = 250
         map.uiSettings.flingAnimationBaseTime = 500
-        map.uiSettings.isDisableRotateWhenScaling = prefs.getBoolean(Prefs.ROTATE_WHILE_ZOOMING, true)
+        map.uiSettings.isDisableRotateWhenScaling = !prefs.getBoolean(Prefs.ROTATE_WHILE_ZOOMING, false)
 
         // workaround for https://github.com/maplibre/maplibre-native/issues/2792
         map.gesturesManager.moveGestureDetector.moveThreshold = resources.dpToPx(5f)

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
@@ -165,7 +165,7 @@ open class MapFragment : Fragment(R.layout.fragment_map) {
 
         // workaround for https://github.com/maplibre/maplibre-native/issues/2792
         map.gesturesManager.moveGestureDetector.moveThreshold = resources.dpToPx(5f)
-        map.gesturesManager.rotateGestureDetector.angleThreshold = prefs.getFloat(Prefs.ROTATE_ANGLE_THRESHOLD, 1.5f)?.toFloatOrNull() ?: 0.0f
+        map.gesturesManager.rotateGestureDetector.angleThreshold = prefs.getString(Prefs.ROTATE_ANGLE_THRESHOLD, "1.5")?.toFloatOrNull() ?: 0.0f
         map.gesturesManager.shoveGestureDetector.pixelDeltaThreshold = resources.dpToPx(8f)
 
         map.addOnMoveListener(object : MapLibreMap.OnMoveListener {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
@@ -161,10 +161,11 @@ open class MapFragment : Fragment(R.layout.fragment_map) {
         map.uiSettings.isLogoEnabled = false
         map.uiSettings.flingThreshold = 250
         map.uiSettings.flingAnimationBaseTime = 500
-        map.uiSettings.isDisableRotateWhenScaling = true
+        map.uiSettings.isDisableRotateWhenScaling = prefs.getBoolean(Prefs.ROTATE_WHILE_ZOOMING, true)
+
         // workaround for https://github.com/maplibre/maplibre-native/issues/2792
         map.gesturesManager.moveGestureDetector.moveThreshold = resources.dpToPx(5f)
-        map.gesturesManager.rotateGestureDetector.angleThreshold = 1.5f
+        map.gesturesManager.rotateGestureDetector.angleThreshold = prefs.getFloat(Prefs.ROTATE_ANGLE_THRESHOLD, ApplicationConstants.ROTATE_ANGLE_THRESHOLD_DEFAULT)
         map.gesturesManager.shoveGestureDetector.pixelDeltaThreshold = resources.dpToPx(8f)
 
         map.addOnMoveListener(object : MapLibreMap.OnMoveListener {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
@@ -165,7 +165,7 @@ open class MapFragment : Fragment(R.layout.fragment_map) {
 
         // workaround for https://github.com/maplibre/maplibre-native/issues/2792
         map.gesturesManager.moveGestureDetector.moveThreshold = resources.dpToPx(5f)
-        map.gesturesManager.rotateGestureDetector.angleThreshold = prefs.getFloat(Prefs.ROTATE_ANGLE_THRESHOLD, 1.5f)
+        map.gesturesManager.rotateGestureDetector.angleThreshold = prefs.getFloat(Prefs.ROTATE_ANGLE_THRESHOLD, 1.5f)?.toFloatOrNull() ?: 0.0f
         map.gesturesManager.shoveGestureDetector.pixelDeltaThreshold = resources.dpToPx(8f)
 
         map.addOnMoveListener(object : MapLibreMap.OnMoveListener {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
@@ -165,7 +165,7 @@ open class MapFragment : Fragment(R.layout.fragment_map) {
 
         // workaround for https://github.com/maplibre/maplibre-native/issues/2792
         map.gesturesManager.moveGestureDetector.moveThreshold = resources.dpToPx(5f)
-        map.gesturesManager.rotateGestureDetector.angleThreshold = prefs.getString(Prefs.ROTATE_ANGLE_THRESHOLD, "1.5")?.toFloatOrNull() ?: 0.0f
+        map.gesturesManager.rotateGestureDetector.angleThreshold = prefs.getInt(Prefs.ROTATE_ANGLE_THRESHOLD, 2).toFloat()
         map.gesturesManager.shoveGestureDetector.pixelDeltaThreshold = resources.dpToPx(8f)
 
         map.addOnMoveListener(object : MapLibreMap.OnMoveListener {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
@@ -165,7 +165,7 @@ open class MapFragment : Fragment(R.layout.fragment_map) {
 
         // workaround for https://github.com/maplibre/maplibre-native/issues/2792
         map.gesturesManager.moveGestureDetector.moveThreshold = resources.dpToPx(5f)
-        map.gesturesManager.rotateGestureDetector.angleThreshold = prefs.getInt(Prefs.ROTATE_ANGLE_THRESHOLD, 2).toFloat()
+        map.gesturesManager.rotateGestureDetector.angleThreshold = prefs.getString(Prefs.ROTATE_ANGLE_THRESHOLD, "1.5")?.toFloatOrNull() ?: 0.0f
         map.gesturesManager.shoveGestureDetector.pixelDeltaThreshold = resources.dpToPx(8f)
 
         map.addOnMoveListener(object : MapLibreMap.OnMoveListener {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/main/map/MapFragment.kt
@@ -165,7 +165,7 @@ open class MapFragment : Fragment(R.layout.fragment_map) {
 
         // workaround for https://github.com/maplibre/maplibre-native/issues/2792
         map.gesturesManager.moveGestureDetector.moveThreshold = resources.dpToPx(5f)
-        map.gesturesManager.rotateGestureDetector.angleThreshold = prefs.getFloat(Prefs.ROTATE_ANGLE_THRESHOLD, ApplicationConstants.ROTATE_ANGLE_THRESHOLD_DEFAULT)
+        map.gesturesManager.rotateGestureDetector.angleThreshold = prefs.getFloat(Prefs.ROTATE_ANGLE_THRESHOLD, 1.5f)
         map.gesturesManager.shoveGestureDetector.pixelDeltaThreshold = resources.dpToPx(8f)
 
         map.addOnMoveListener(object : MapLibreMap.OnMoveListener {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/UiSettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/UiSettingsFragment.kt
@@ -15,6 +15,7 @@ import androidx.appcompat.widget.Toolbar
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.preference.DialogPreference
+import androidx.preference.EditTextPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/UiSettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/UiSettingsFragment.kt
@@ -95,6 +95,10 @@ class UiSettingsFragment : PreferenceFragmentCompat(), HasTitle {
             builder.show()
             true
         }
+
+        findPreference<Preference>(Prefs.ROTATE_ANGLE_THRESHOLD)?.setOnBindEditTextListener {
+            editText -> editText.inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL
+        }
     }
 
     override fun onDisplayPreferenceDialog(preference: Preference) {

--- a/app/src/main/java/de/westnordost/streetcomplete/screens/settings/UiSettingsFragment.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/screens/settings/UiSettingsFragment.kt
@@ -96,7 +96,7 @@ class UiSettingsFragment : PreferenceFragmentCompat(), HasTitle {
             true
         }
 
-        findPreference<Preference>(Prefs.ROTATE_ANGLE_THRESHOLD)?.setOnBindEditTextListener {
+        findPreference<EditTextPreference>(Prefs.ROTATE_ANGLE_THRESHOLD)?.setOnBindEditTextListener {
             editText -> editText.inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL
         }
     }

--- a/app/src/main/res/values/strings_ee.xml
+++ b/app/src/main/res/values/strings_ee.xml
@@ -80,6 +80,8 @@
     <string name="pref_screen_ui">UI</string>
     <string name="pref_volume_zoom_title">Volume button zoom</string>
     <string name="pref_volume_zoom_summary">Zoom using volume buttons</string>
+    <string name="pref_rotate_while_zooming_title">Allow rotate while zooming</string>
+    <string name="pref_rotate_angle_threshold_title">Threshold for rotate gesture</string>
     <string name="pref_show_quick_settings_title">Show quick settings button</string>
     <string name="pref_select_first_edit_title">Select first edit on opening history</string>
     <string name="pref_select_first_edit_summary">Allows for quicker undo, but moves camera automatically</string>

--- a/app/src/main/res/values/strings_ee.xml
+++ b/app/src/main/res/values/strings_ee.xml
@@ -82,6 +82,8 @@
     <string name="pref_volume_zoom_summary">Zoom using volume buttons</string>
     <string name="pref_rotate_while_zooming_title">Allow rotate while zooming</string>
     <string name="pref_rotate_angle_threshold_title">Threshold for rotate gesture</string>
+    <string name="pref_rotate_angle_threshold_summary">If rotated more than %d degree(s)</string>
+    <string name="pref_rotate_angle_threshold_message">Start rotation gesture if fingers were rotating at least this many degrees</string>
     <string name="pref_show_quick_settings_title">Show quick settings button</string>
     <string name="pref_select_first_edit_title">Select first edit on opening history</string>
     <string name="pref_select_first_edit_summary">Allows for quicker undo, but moves camera automatically</string>

--- a/app/src/main/res/values/strings_ee.xml
+++ b/app/src/main/res/values/strings_ee.xml
@@ -82,8 +82,6 @@
     <string name="pref_volume_zoom_summary">Zoom using volume buttons</string>
     <string name="pref_rotate_while_zooming_title">Allow rotate while zooming</string>
     <string name="pref_rotate_angle_threshold_title">Threshold for rotate gesture</string>
-    <string name="pref_rotate_angle_threshold_summary">If rotated more than %d degree(s)</string>
-    <string name="pref_rotate_angle_threshold_message">Start rotation gesture if fingers were rotating at least this many degrees</string>
     <string name="pref_show_quick_settings_title">Show quick settings button</string>
     <string name="pref_select_first_edit_title">Select first edit on opening history</string>
     <string name="pref_select_first_edit_summary">Allows for quicker undo, but moves camera automatically</string>

--- a/app/src/main/res/xml/preferences_ee_ui.xml
+++ b/app/src/main/res/xml/preferences_ee_ui.xml
@@ -120,13 +120,19 @@
         android:defaultValue="false"
         android:persistent="true" />
 
-    <EditTextPreference
+    <de.westnordost.streetcomplete.screens.settings.NumberPickerPreference
         app:iconSpaceReserved="false"
         android:key="rotate_angle_threshold"
-        android:inputType="numberDecimal"
-        android:numeric="decimal"
         android:title="@string/pref_rotate_angle_threshold_title"
-        android:defaultValue="1.5"
-        android:persistent="true" />
+        android:summary="@string/pref_rotate_angle_threshold_summary"
+        android:defaultValue="2"
+        android:persistent="true"
+        app:minValue="0"
+        app:maxValue="90"
+        app:step="1"
+        android:dialogMessage="@string/pref_rotate_angle_threshold_message"
+        android:dialogLayout="@layout/dialog_number_picker_preference"
+        android:positiveButtonText="@android:string/ok"
+        android:negativeButtonText="@android:string/cancel" />
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences_ee_ui.xml
+++ b/app/src/main/res/xml/preferences_ee_ui.xml
@@ -123,11 +123,9 @@
     <EditTextPreference
         app:iconSpaceReserved="false"
         android:key="rotate_angle_threshold"
-        android:inputType="numberDecimal"
-        android:digits="0123456789."
-        android:numeric="decimal"
+        android:inputType="numberPassword"
         android:title="@string/pref_rotate_angle_threshold_title"
-        android:defaultValue="1.5"
+        android:defaultValue="1.6"
         android:persistent="true" />
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences_ee_ui.xml
+++ b/app/src/main/res/xml/preferences_ee_ui.xml
@@ -117,7 +117,7 @@
         app:iconSpaceReserved="false"
         android:key="rotate_while_zooming"
         android:title="@string/pref_rotate_while_zooming_title"
-        android:defaultValue="true"
+        android:defaultValue="false"
         android:persistent="true" />
 
     <EditTextPreference

--- a/app/src/main/res/xml/preferences_ee_ui.xml
+++ b/app/src/main/res/xml/preferences_ee_ui.xml
@@ -124,6 +124,7 @@
         app:iconSpaceReserved="false"
         android:key="rotate_angle_threshold"
         android:inputType="numberDecimal"
+        android:digits="0123456789."
         android:numeric="decimal"
         android:title="@string/pref_rotate_angle_threshold_title"
         android:defaultValue="1.5"

--- a/app/src/main/res/xml/preferences_ee_ui.xml
+++ b/app/src/main/res/xml/preferences_ee_ui.xml
@@ -123,9 +123,8 @@
     <EditTextPreference
         app:iconSpaceReserved="false"
         android:key="rotate_angle_threshold"
-        android:inputType="numberPassword"
         android:title="@string/pref_rotate_angle_threshold_title"
-        android:defaultValue="1.6"
+        android:defaultValue="1.5"
         android:persistent="true" />
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences_ee_ui.xml
+++ b/app/src/main/res/xml/preferences_ee_ui.xml
@@ -120,19 +120,13 @@
         android:defaultValue="false"
         android:persistent="true" />
 
-    <de.westnordost.streetcomplete.screens.settings.NumberPickerPreference
+    <EditTextPreference
         app:iconSpaceReserved="false"
         android:key="rotate_angle_threshold"
+        android:inputType="numberDecimal"
+        android:numeric="decimal"
         android:title="@string/pref_rotate_angle_threshold_title"
-        android:summary="@string/pref_rotate_angle_threshold_summary"
-        android:defaultValue="2"
-        android:persistent="true"
-        app:minValue="0"
-        app:maxValue="90"
-        app:step="1"
-        android:dialogMessage="@string/pref_rotate_angle_threshold_message"
-        android:dialogLayout="@layout/dialog_number_picker_preference"
-        android:positiveButtonText="@android:string/ok"
-        android:negativeButtonText="@android:string/cancel" />
+        android:defaultValue="1.5"
+        android:persistent="true" />
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences_ee_ui.xml
+++ b/app/src/main/res/xml/preferences_ee_ui.xml
@@ -113,4 +113,19 @@
         android:defaultValue="false"
         android:persistent="true" />
 
+    <SwitchPreference
+        app:iconSpaceReserved="false"
+        android:key="rotate_while_zooming"
+        android:title="@string/pref_rotate_while_zooming_title"
+        android:defaultValue="true"
+        android:persistent="true" />
+
+    <EditTextPreference
+        app:iconSpaceReserved="false"
+        android:key="rotate_angle_threshold"
+        android:inputType="numberDecimal"
+        android:title="@string/pref_rotate_angle_threshold_title"
+        android:defaultValue="1.5f"
+        android:persistent="true" />
+
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences_ee_ui.xml
+++ b/app/src/main/res/xml/preferences_ee_ui.xml
@@ -124,8 +124,9 @@
         app:iconSpaceReserved="false"
         android:key="rotate_angle_threshold"
         android:inputType="numberDecimal"
+        android:numeric="decimal"
         android:title="@string/pref_rotate_angle_threshold_title"
-        android:defaultValue="1.5f"
+        android:defaultValue="1.5"
         android:persistent="true" />
 
 </PreferenceScreen>


### PR DESCRIPTION
- adds _"Allow rotate while zooming"_ boolean
- adds _"Threshold for rotate gesture"_ slider

Fixes https://github.com/Helium314/SCEE/issues/620

Debug `.apk` here: https://github.com/mnalis/StreetComplete/actions/runs/12941287755
Seems to work for me, but extra testing welcome!