### PR TITLE
when marking a building as demolished, remove obsolete tags

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/AbstractOverlayForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/AbstractOverlayForm.kt
@@ -548,6 +548,8 @@ abstract class AbstractOverlayForm :
                                 val builder = StringMapChangesBuilder(element.tags)
                                 builder["demolished:building"] = builder["building"] ?: "yes"
                                 builder.remove("building")
+                                builder.keys.toList().filter { it.matches(Regex("^(building:|roof:)")) }
+                                    .forEach { builder.remove(it) }
                                 solve(UpdateElementTagsAction(element, builder.create()), geometry, true)
                             }
                         } else {

--- a/app/src/main/java/de/westnordost/streetcomplete/overlays/AbstractOverlayForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/overlays/AbstractOverlayForm.kt
@@ -548,7 +548,7 @@ abstract class AbstractOverlayForm :
                                 val builder = StringMapChangesBuilder(element.tags)
                                 builder["demolished:building"] = builder["building"] ?: "yes"
                                 builder.remove("building")
-                                builder.keys.toList().filter { it.matches(Regex("^(building:|roof:)")) }
+                                builder.keys.toList().filter { it.matches(Regex("^(building:|roof:).*")) }
                                     .forEach { builder.remove(it) }
                                 solve(UpdateElementTagsAction(element, builder.create()), geometry, true)
                             }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractOsmQuestForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractOsmQuestForm.kt
@@ -453,7 +453,7 @@ abstract class AbstractOsmQuestForm<T> : AbstractQuestForm(), IsShowingQuestDeta
                                 val builder = StringMapChangesBuilder(element.tags)
                                 builder["demolished:building"] = builder["building"] ?: "yes"
                                 builder.remove("building")
-                                builder.keys.toList().filter { it.matches(Regex("^(building:|roof:)")) }
+                                builder.keys.toList().filter { it.matches(Regex("^(building:|roof:).*")) }
                                     .forEach { builder.remove(it) }
                                 solve(UpdateElementTagsAction(element, builder.create()), true)
                             }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractOsmQuestForm.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/AbstractOsmQuestForm.kt
@@ -453,6 +453,8 @@ abstract class AbstractOsmQuestForm<T> : AbstractQuestForm(), IsShowingQuestDeta
                                 val builder = StringMapChangesBuilder(element.tags)
                                 builder["demolished:building"] = builder["building"] ?: "yes"
                                 builder.remove("building")
+                                builder.keys.toList().filter { it.matches(Regex("^(building:|roof:)")) }
+                                    .forEach { builder.remove(it) }
                                 solve(UpdateElementTagsAction(element, builder.create()), true)
                             }
                         } else {


### PR DESCRIPTION
When `building` is marked as `demolished` in SCEE,  `building:*` and `roof:*` tags are obsolete and confusing (and might cause mistriggering of the other quests); so we better remove them.

Fixes: https://github.com/Helium314/SCEE/issues/752

tested in https://github.com/mnalis/StreetComplete/actions/runs/13777125698, seems to work fine

<Details>
<summary>screenshot</summary>

![small_Screenshot_20250311_012522_SCEE Dev](https://github.com/user-attachments/assets/38649e6f-de58-4976-8e70-6c0991db2674)


</details>