### PR TITLE
Ask for lamp type also on generic values

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/lamp_type/AddLampType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/lamp_type/AddLampType.kt
@@ -17,7 +17,7 @@ class AddLampType : OsmFilterQuestType<String>() {
         nodes with
           highway = street_lamp
           and ( !lamp_type or lamp_type ~ electric|floodlight|sodium|solar_lamp )
-          and !light:method
+          and ( !light:method or light:method ~ electric|discharge|sodium )
     """
     override val changesetComment = "Add lamp type"
     override val defaultDisabledMessage = R.string.quest_lampType_disabled_msg

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/lamp_type/AddLampType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/lamp_type/AddLampType.kt
@@ -16,7 +16,7 @@ class AddLampType : OsmFilterQuestType<String>() {
     override val elementFilter = """
         nodes with
           highway = street_lamp
-          and !lamp_type
+          and ( !lamp_type or lamp_type ~ electric|floodlight|sodium|solar_lamp )
           and !light:method
     """
     override val changesetComment = "Add lamp type"

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/lamp_type/AddLampType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/lamp_type/AddLampType.kt
@@ -35,5 +35,6 @@ class AddLampType : OsmFilterQuestType<String>() {
 
     override fun applyAnswerTo(answer: String, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
         tags["lamp_type"] = answer
+        tags.remove("light:method")
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/lamp_type/AddLampType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/lamp_type/AddLampType.kt
@@ -35,6 +35,8 @@ class AddLampType : OsmFilterQuestType<String>() {
 
     override fun applyAnswerTo(answer: String, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
         tags["lamp_type"] = answer
-        tags.remove("light:method")
+        if (tags["light:method"] in listOf("electric", "discharge", "sodium")) {
+            tags.remove("light:method")
+        }
     }
 }

--- a/app/src/main/java/de/westnordost/streetcomplete/quests/lamp_type/AddLampType.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/lamp_type/AddLampType.kt
@@ -16,8 +16,8 @@ class AddLampType : OsmFilterQuestType<String>() {
     override val elementFilter = """
         nodes with
           highway = street_lamp
-          and ( !lamp_type or lamp_type ~ electric|floodlight|sodium|solar_lamp )
-          and ( !light:method or light:method ~ electric|discharge|sodium )
+          and (!lamp_type or lamp_type ~ electric|floodlight|sodium|solar_lamp)
+          and (!light:method or light:method ~ electric|discharge|sodium)
     """
     override val changesetComment = "Add lamp type"
     override val defaultDisabledMessage = R.string.quest_lampType_disabled_msg


### PR DESCRIPTION
see https://wiki.openstreetmap.org/wiki/Key:lamp_type#Generic_values
and https://wiki.openstreetmap.org/wiki/Key:light:method

(Fixes https://github.com/streetcomplete/StreetComplete/discussions/6168 which was opened in wrong repository)

seems to compile and work: https://github.com/mnalis/StreetComplete/actions/runs/13902048906