### PR TITLE
For trail_visibility, ignore sac_scale=strolling

### DIFF
--- a/app/src/main/java/de/westnordost/streetcomplete/quests/trail_visibility/AddTrailVisibility.kt
+++ b/app/src/main/java/de/westnordost/streetcomplete/quests/trail_visibility/AddTrailVisibility.kt
@@ -15,7 +15,7 @@ class AddTrailVisibility : OsmFilterQuestType<TrailVisibility>() {
           highway ~ path|footway|cycleway|bridleway
           and !trail_visibility
           and ( access !~ no|private or foot ~ yes|permissive|designated or bicycle ~ yes|permissive|designated)
-          and (sac_scale and sac_scale != hiking)
+          and (sac_scale and sac_scale !~ hiking|strolling)
           and (!lit or lit = no)
           and surface ~ "ground|earth|dirt|soil|grass|sand|mud|ice|salt|snow|rock|stone"
     """


### PR DESCRIPTION
as "strolling" is new [sac_scale](https://wiki.openstreetmap.org/wiki/Sac_scale)  value, even easier than "hiking"...

(and "hiking" is excluded due to  false positives, see e.g. https://github.com/Helium314/SCEE/issues/478#issuecomment-1791936098 and below)