### PR TITLE
Update buildingMaterial quest wording

### DIFF
--- a/app/src/main/res/values/strings_ee.xml
+++ b/app/src/main/res/values/strings_ee.xml
@@ -784,8 +784,8 @@ Out of the box SCEE is configured to behave very similar to StreetComplete.</str
     <string name="quest_roofOrientation_title">How is the roof ridge oriented?</string>
 
     <!-- building material -->
-    <string name="quest_buildingMaterial_title">"What overall material is this building made of?"</string>
-    <string name="quest_buildingPartMaterial_title">"What overall material is this building part made of?"</string>
+    <string name="quest_buildingMaterial_title">"What material is this building's facade made of?"</string>
+    <string name="quest_buildingPartMaterial_title">"What material is this building part's facade made of?"</string>
     <string name="quest_material_cement_block">Cement block</string>
     <string name="quest_material_plaster">Plaster</string>
     <string name="quest_material_glass">Glass</string>


### PR DESCRIPTION
https://wiki.openstreetmap.org/wiki/Key:building:material states that "The key building:material=* is used to describe the outer surface material of building walls, also know as the facade or façade."

Asking "What material is this building made of" is confusing since one would assume that's talking about the structural element of the building, which is often different to the building cladding or facade material.

For example a steel frame building with some other cladding material, or a timber frame building with brick cladding, or a brick structure with cement render as the facade material.

Translators can translate facade based on each locale, but for the default English in my view we need to be clear that this is asking about the external surface material, and not "what the building is made of".

Instead of facade you could ask, "what is the material of the outer surface of the building".