### PR TITLE
Avoid mis-detection of changed tags in tag editor

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/TagEditor.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/TagEditor.kt
@@ -402,8 +402,10 @@ open class TagEditor : Fragment(), IsCloseableBottomSheet {
 
     private fun tagsChangedAndOk(): Boolean =
         originalElement.tags != HashMap<String, String>().apply {
-            putAll(newTags)
-            entries.removeAll { it.key.isBlank() && it.value.isBlank() }
+            newTags.forEach { (k, v) ->
+                if (k.isBlank() || v.isBlank()) return@forEach
+                put(k.trim(), v.trim())
+            }
         }
             && newTags.none {
                 (it.key.isBlank() && it.value.isNotBlank()) || (it.value.isBlank() && it.key.isNotBlank())


### PR DESCRIPTION
Compare trimmed version of newTags with original tags, so ok button is not shown when just adding whitespace at start or end of a key or value.