### PR TITLE
Feature/859 enhance add barrier locked quest

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/barrier_locked/AddBarrierLocked.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/barrier_locked/AddBarrierLocked.kt
@@ -1,23 +1,20 @@
 package de.westnordost.streetcomplete.quests.barrier_locked
 
 import de.westnordost.streetcomplete.R
-import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Element
 import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
 import de.westnordost.streetcomplete.data.osm.mapdata.Node
 import de.westnordost.streetcomplete.data.osm.mapdata.Way
-import de.westnordost.streetcomplete.data.osm.mapdata.filter
-import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
 import de.westnordost.streetcomplete.osm.Tags
-import de.westnordost.streetcomplete.resources.Res
-import de.westnordost.streetcomplete.resources.default_disabled_msg_ee
+import de.westnordost.streetcomplete.resources.*
 
-class AddBarrierLocked : OsmElementQuestType<BarrierLockedAnswer>, AndroidQuest {
+class AddBarrierLocked : OsmFilterQuestType<BarrierLockedAnswer>(), AndroidQuest {
 
     // We keep nodes and ways because many barriers are mapped as ways in OSM.
-    private val barrierLockedFilterExpression = """
+    override val elementFilter = """
         nodes, ways with
           barrier ~ bump_gate|chain|door|gate|swing_gate|sliding_gate|sliding_beam|wicket_gate
         and (
@@ -26,9 +23,6 @@ class AddBarrierLocked : OsmElementQuestType<BarrierLockedAnswer>, AndroidQuest 
           or locked older today -10 years
         )
     """
-
-    // local filter expression derived from elementFilter (used by isApplicableTo)
-    private val filter by lazy { barrierLockedFilterExpression.toElementFilterExpression() }
 
     override val changesetComment = "Add whether barriers are locked"
     override val wikiLink = "Key:locked"
@@ -39,17 +33,8 @@ class AddBarrierLocked : OsmElementQuestType<BarrierLockedAnswer>, AndroidQuest 
 
     override fun createForm() = AddBarrierLockedForm()
 
-    override fun isApplicableTo(element: Element): Boolean? {
-        if (!filter.matches(element)) return false
-
-        // Element matches the base filter -> we need surrounding map data to decide precisely.
-        // Return null so getApplicableElements(mapData) is used for the final decision.
-        return null
-    }
-
     override fun getApplicableElements(mapData: MapDataWithGeometry): Iterable<Element> {
-        // Start with all elements that match the configured filter string
-        val filteredElements = mapData.filter(barrierLockedFilterExpression).asIterable()
+        val base = super.getApplicableElements(mapData)
 
         // Build a lookup from node id to the ways that are connected to it
         val waysByNodeId = mutableMapOf<Long, MutableList<Way>>()
@@ -60,7 +45,7 @@ class AddBarrierLocked : OsmElementQuestType<BarrierLockedAnswer>, AndroidQuest 
             }
         }
 
-        val nodeResults = filteredElements
+        return base
             .filterIsInstance<Node>()
             .filter { node ->
                 val connectedWays = waysByNodeId[node.id].orEmpty()
@@ -76,7 +61,6 @@ class AddBarrierLocked : OsmElementQuestType<BarrierLockedAnswer>, AndroidQuest 
                     when (access) {
                         null -> noAccessTagCount++
                         "private", "no" -> restrictedCount++
-                        else -> { /* ignore other access values */ }
                     }
                 }
 
@@ -84,12 +68,6 @@ class AddBarrierLocked : OsmElementQuestType<BarrierLockedAnswer>, AndroidQuest 
                 // and exactly one connected way has no access tag.
                 !(restrictedCount == 1 && noAccessTagCount == 1)
             }
-
-        val wayResults = filteredElements
-            .filterIsInstance<Way>()
-
-        // Combine results: nodes + ways that passed the checks
-        return nodeResults + wayResults
     }
 
     override fun applyAnswerTo(answer: BarrierLockedAnswer, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/barrier_locked/AddBarrierLocked.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/barrier_locked/AddBarrierLocked.kt
@@ -1,16 +1,22 @@
 package de.westnordost.streetcomplete.quests.barrier_locked
 
 import de.westnordost.streetcomplete.R
+import de.westnordost.streetcomplete.data.elementfilter.toElementFilterExpression
 import de.westnordost.streetcomplete.data.osm.geometry.ElementGeometry
-import de.westnordost.streetcomplete.data.osm.osmquests.OsmFilterQuestType
-import de.westnordost.streetcomplete.osm.Tags
+import de.westnordost.streetcomplete.data.osm.mapdata.Element
+import de.westnordost.streetcomplete.data.osm.mapdata.MapDataWithGeometry
+import de.westnordost.streetcomplete.data.osm.mapdata.Node
+import de.westnordost.streetcomplete.data.osm.mapdata.Way
+import de.westnordost.streetcomplete.data.osm.mapdata.filter
+import de.westnordost.streetcomplete.data.osm.osmquests.OsmElementQuestType
 import de.westnordost.streetcomplete.data.quest.AndroidQuest
+import de.westnordost.streetcomplete.osm.Tags
 import de.westnordost.streetcomplete.resources.Res
 import de.westnordost.streetcomplete.resources.default_disabled_msg_ee
 
-class AddBarrierLocked : OsmFilterQuestType<BarrierLockedAnswer>(), AndroidQuest {
+class AddBarrierLocked : OsmElementQuestType<BarrierLockedAnswer>, AndroidQuest {
 
-    override val elementFilter = """
+    private val elementFilter = """
         nodes, ways with
           barrier ~ bump_gate|chain|door|gate|swing_gate|sliding_gate|sliding_beam|wicket_gate
         and (
@@ -19,6 +25,10 @@ class AddBarrierLocked : OsmFilterQuestType<BarrierLockedAnswer>(), AndroidQuest
           or locked older today -10 years
         )
     """
+
+    // local filter expression derived from elementFilter (used by isApplicableTo)
+    private val filter by lazy { elementFilter.toElementFilterExpression() }
+
     override val changesetComment = "Add whether barriers are locked"
     override val wikiLink = "Key:locked"
     override val icon = R.drawable.ic_quest_barrier_locked
@@ -27,6 +37,56 @@ class AddBarrierLocked : OsmFilterQuestType<BarrierLockedAnswer>(), AndroidQuest
     override fun getTitle(tags: Map<String, String>) = R.string.quest_barrier_locked_title
 
     override fun createForm() = AddBarrierLockedForm()
+
+    override fun isApplicableTo(element: Element): Boolean? {
+        // Only barrier nodes are relevant
+        if (element !is Node) return false
+
+        // Apply the element filter for quick exclusion
+        if (!filter.matches(element)) return false
+
+        // Need surrounding map data to decide
+        return null
+    }
+
+    override fun getApplicableElements(mapData: MapDataWithGeometry): Iterable<Element> {
+        // Start with all elements that match the configured filter string
+        val filteredElements = mapData.filter(elementFilter).asIterable()
+
+        // Build a lookup from node id to the ways that are connected to it
+        val waysByNodeId = mutableMapOf<Long, MutableList<Way>>()
+        for (way in mapData.ways) {
+            for (nodeId in way.nodeIds) {
+                waysByNodeId.getOrPut(nodeId) { mutableListOf() }.add(way)
+            }
+        }
+
+        return filteredElements
+            // Only nodes are relevant here; barrier ways are intentionally ignored
+            .filterIsInstance<Node>()
+            .filter { node ->
+                val connectedWays = waysByNodeId[node.id].orEmpty()
+
+                // optional small short-circuit: if fewer than 2 ways, cannot match (1,1)
+                if (connectedWays.size < 2) return@filter true
+
+                var restrictedCount = 0
+                var noAccessTagCount = 0
+
+                for (way in connectedWays) {
+                    val access = way.tags["access"]
+                    when (access) {
+                        null -> noAccessTagCount++
+                        "private", "no" -> restrictedCount++
+                        else -> { /* ignore other access values */ }
+                    }
+                }
+
+                // Exclude nodes where exactly one connected way has access=private|no
+                // and exactly one connected way has no access tag.
+                !(restrictedCount == 1 && noAccessTagCount == 1)
+            }
+    }
 
     override fun applyAnswerTo(answer: BarrierLockedAnswer, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {
         answer.applyTo(tags)

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/barrier_locked/AddBarrierLocked.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/barrier_locked/AddBarrierLocked.kt
@@ -16,6 +16,7 @@ import de.westnordost.streetcomplete.resources.default_disabled_msg_ee
 
 class AddBarrierLocked : OsmElementQuestType<BarrierLockedAnswer>, AndroidQuest {
 
+    // We keep nodes and ways because many barriers are mapped as ways in OSM.
     private val barrierLockedFilterExpression = """
         nodes, ways with
           barrier ~ bump_gate|chain|door|gate|swing_gate|sliding_gate|sliding_beam|wicket_gate
@@ -39,13 +40,10 @@ class AddBarrierLocked : OsmElementQuestType<BarrierLockedAnswer>, AndroidQuest 
     override fun createForm() = AddBarrierLockedForm()
 
     override fun isApplicableTo(element: Element): Boolean? {
-        // Only barrier nodes are relevant
-        if (element !is Node) return false
-
-        // Apply the element filter for quick exclusion
         if (!filter.matches(element)) return false
 
-        // Need surrounding map data to decide
+        // Element matches the base filter -> we need surrounding map data to decide precisely.
+        // Return null so getApplicableElements(mapData) is used for the final decision.
         return null
     }
 
@@ -56,13 +54,13 @@ class AddBarrierLocked : OsmElementQuestType<BarrierLockedAnswer>, AndroidQuest 
         // Build a lookup from node id to the ways that are connected to it
         val waysByNodeId = mutableMapOf<Long, MutableList<Way>>()
         for (way in mapData.ways) {
+            if (way.tags["highway"] == null) continue // restrict to highway ways for relevance
             for (nodeId in way.nodeIds) {
                 waysByNodeId.getOrPut(nodeId) { mutableListOf() }.add(way)
             }
         }
 
-        return filteredElements
-            // Only nodes are relevant here; barrier ways are intentionally ignored
+        val nodeResults = filteredElements
             .filterIsInstance<Node>()
             .filter { node ->
                 val connectedWays = waysByNodeId[node.id].orEmpty()
@@ -86,6 +84,12 @@ class AddBarrierLocked : OsmElementQuestType<BarrierLockedAnswer>, AndroidQuest 
                 // and exactly one connected way has no access tag.
                 !(restrictedCount == 1 && noAccessTagCount == 1)
             }
+
+        val wayResults = filteredElements
+            .filterIsInstance<Way>()
+
+        // Combine results: nodes + ways that passed the checks
+        return nodeResults + wayResults
     }
 
     override fun applyAnswerTo(answer: BarrierLockedAnswer, tags: Tags, geometry: ElementGeometry, timestampEdited: Long) {

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/barrier_locked/AddBarrierLocked.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/barrier_locked/AddBarrierLocked.kt
@@ -16,7 +16,7 @@ import de.westnordost.streetcomplete.resources.default_disabled_msg_ee
 
 class AddBarrierLocked : OsmElementQuestType<BarrierLockedAnswer>, AndroidQuest {
 
-    private val elementFilter = """
+    private val barrierLockedFilterExpression = """
         nodes, ways with
           barrier ~ bump_gate|chain|door|gate|swing_gate|sliding_gate|sliding_beam|wicket_gate
         and (
@@ -27,7 +27,7 @@ class AddBarrierLocked : OsmElementQuestType<BarrierLockedAnswer>, AndroidQuest 
     """
 
     // local filter expression derived from elementFilter (used by isApplicableTo)
-    private val filter by lazy { elementFilter.toElementFilterExpression() }
+    private val filter by lazy { barrierLockedFilterExpression.toElementFilterExpression() }
 
     override val changesetComment = "Add whether barriers are locked"
     override val wikiLink = "Key:locked"
@@ -51,7 +51,7 @@ class AddBarrierLocked : OsmElementQuestType<BarrierLockedAnswer>, AndroidQuest 
 
     override fun getApplicableElements(mapData: MapDataWithGeometry): Iterable<Element> {
         // Start with all elements that match the configured filter string
-        val filteredElements = mapData.filter(elementFilter).asIterable()
+        val filteredElements = mapData.filter(barrierLockedFilterExpression).asIterable()
 
         // Build a lookup from node id to the ways that are connected to it
         val waysByNodeId = mutableMapOf<Long, MutableList<Way>>()

--- a/app/src/androidUnitTest/kotlin/de/westnordost/streetcomplete/quests/barrier_locked/AddBarrierLockedTest.kt
+++ b/app/src/androidUnitTest/kotlin/de/westnordost/streetcomplete/quests/barrier_locked/AddBarrierLockedTest.kt
@@ -1,0 +1,53 @@
+package de.westnordost.streetcomplete.quests.barrier_locked
+
+import de.westnordost.streetcomplete.quests.TestMapDataWithGeometry
+import de.westnordost.streetcomplete.testutils.node
+import de.westnordost.streetcomplete.testutils.way
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AddBarrierLockedTest {
+
+    private val questType = AddBarrierLocked()
+
+    @Test
+    fun `no quest for barrier node with one restricted and one unrestricted connected way`() {
+        val barrierNode = node(
+            1,
+            tags = mapOf(
+                "barrier" to "gate",
+                "locked" to "yes"
+            ),
+        )
+
+        val privateWay = way(
+            1,
+            listOf(1, 2),
+            mapOf(
+                "highway" to "service",
+                "access" to "private",
+            ),
+        )
+
+        val publicWay = way(
+            2,
+            listOf(1, 3),
+            mapOf(
+                "highway" to "service",
+            ),
+        )
+
+        val mapData = TestMapDataWithGeometry(
+            listOf(
+                barrierNode,
+                node(2),
+                node(3),
+                privateWay,
+                publicWay,
+            ),
+        )
+
+        val applicable = questType.getApplicableElements(mapData).toList()
+        assertEquals(emptyList(), applicable)
+    }
+}

--- a/app/src/androidUnitTest/kotlin/de/westnordost/streetcomplete/quests/barrier_locked/AddBarrierLockedTest.kt
+++ b/app/src/androidUnitTest/kotlin/de/westnordost/streetcomplete/quests/barrier_locked/AddBarrierLockedTest.kt
@@ -21,7 +21,7 @@ class AddBarrierLockedTest {
         )
 
         val privateWay = way(
-            1,
+            11,
             listOf(1, 2),
             mapOf(
                 "highway" to "service",
@@ -30,7 +30,7 @@ class AddBarrierLockedTest {
         )
 
         val publicWay = way(
-            2,
+            12,
             listOf(1, 3),
             mapOf(
                 "highway" to "service",
@@ -49,5 +49,39 @@ class AddBarrierLockedTest {
 
         val applicable = questType.getApplicableElements(mapData).toList()
         assertEquals(emptyList(), applicable)
+    }
+    @Test
+    fun `quest shown for barrier node with two unrestricted connected ways`() {
+        val barrierNode = node(
+            1,
+            tags = mapOf("barrier" to "gate")
+        )
+
+        val wayA = way(
+            11,
+            listOf(1, 2),
+            mapOf("highway" to "service")
+        )
+
+        val wayB = way(
+            12,
+            listOf(1, 3),
+            mapOf("highway" to "service")
+        )
+
+        val mapData = TestMapDataWithGeometry(
+            listOf(
+                barrierNode,
+                node(2),
+                node(3),
+                wayA,
+                wayB,
+            ),
+        )
+
+        val applicable = questType.getApplicableElements(mapData).toList()
+
+        assertEquals(1, applicable.size)
+        assertEquals(barrierNode, applicable.first())
     }
 }


### PR DESCRIPTION
See comments here https://github.com/Helium314/SCEE/issues/859 for context.

### Visual Test
**Example:**
In the first screenshot, you can see that there are two barrier=gate nodes on this dead-end road. One (on the right) is in the middle of the road, while the left node is directly at the split. 
<img width="381" height="326" alt="Image" src="https://github.com/user-attachments/assets/ed73f80b-219e-4e04-af50-9628d8252a15" />
To the left of the split (see surface overlay with dashed line) is access=private. The right road has nothing. Here, the quest is only displayed where the barrier is located in the middle of the public way.
<img width="375" height="299" alt="Image" src="https://github.com/user-attachments/assets/4a901356-dd48-4b1f-84e8-f37f6406ecc6" />

**Unit Test:**
This is the first time I've written a unit test, so please feel free to give me direct feedback!
<img width="139" height="20" alt="image" src="https://github.com/user-attachments/assets/7dbb4370-2902-4e0d-89d8-1bcfecdae44a" />

Closes #859 