### PR TITLE
Do not ask building colour for underground buildings

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/building_colour/AddBuildingColour.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/building_colour/AddBuildingColour.kt
@@ -17,6 +17,7 @@ class AddBuildingColour : OsmFilterQuestType<BuildingColour>(), AndroidQuest {
           and !building:colour
           and (!indoor or indoor = no)
           and wall !~ no
+          and location != underground
     """
     override val changesetComment = "Specify building colour"
     override val wikiLink = "Key:building:colour"


### PR DESCRIPTION
Exclude underground buildings (`location=underground`) from the building colour quest, as such buildings have no visible exterior colour.

Fixes #635.