### PR TITLE
Add support for bbox-epsg-3857

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/map/components/SceneMapComponent.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/main/map/components/SceneMapComponent.kt
@@ -53,7 +53,7 @@ class SceneMapComponent(
         }
         val styleJsonString = when {
             prefs.prefs.getString(Prefs.THEME_BACKGROUND, "MAP") != "MAP" ->
-                createMapStyle("StreetComplete-Raster", token, emptyList(), rasterBackground(prefs.prefs.getBoolean(Prefs.NO_SATELLITE_LABEL, false)), prefs.prefs.getString(Prefs.RASTER_TILE_URL, ApplicationConstants.RASTER_DEFAULT_URL), prefs.prefs.getInt(Prefs.RASTER_TILE_MAXZOOM, ApplicationConstants.RASTER_DEFAULT_MAXZOOM))
+                createMapStyle("StreetComplete-Raster", token, emptyList(), rasterBackground(prefs.prefs.getBoolean(Prefs.NO_SATELLITE_LABEL, false)), getRasterTileUrl(), prefs.prefs.getInt(Prefs.RASTER_TILE_MAXZOOM, ApplicationConstants.RASTER_DEFAULT_MAXZOOM))
             prefs.theme == Theme.DARK_CONTRAST -> createMapStyle("StreetComplete-Dark_Contrast", token, emptyList(), themeDarkContrast)
             isNightMode -> context.resources.assets.open("map_theme/streetcomplete-night.json").bufferedReader().use { it.readText() }
             else -> context.resources.assets.open("map_theme/streetcomplete.json").bufferedReader().use { it.readText() }
@@ -63,6 +63,15 @@ class SceneMapComponent(
         val style = map.awaitSetStyle(styleBuilder)
         withContext(Dispatchers.Main) { updateStyle() }
         return style
+    }
+
+    private fun getRasterTileUrl(): String {
+        val url = prefs.prefs.getString(Prefs.RASTER_TILE_URL, ApplicationConstants.RASTER_DEFAULT_URL)
+        return url.replace("{zoom}", "{z}")
+            .replace("{bbox}", "{bbox-epsg-3857}")
+            .replace("{width}", "256")
+            .replace("{height}", "256")
+            .replace("{proj}", "EPSG:3857")
     }
 
     /** Updates part of the style depending on the user settings:

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/DataManagementScreen.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/DataManagementScreen.kt
@@ -299,7 +299,9 @@ private fun showRasterUrlDialog(context: Context, prefs: SharedPreferences) {
         setText(currentUrl)
         doAfterTextChanged {
             val t = it.toString()
-            d?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled = t.contains("{x}") && t.contains("{y}") && t.contains("{z}")
+            d?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled =
+                (t.contains("{x}") && t.contains("{y}") && t.contains("{z}")) ||
+                    t.contains("{bbox-epsg-3857}")
         }
     }
     val hideLabelsSwitch = SwitchCompat(context).apply {

--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/DataManagementScreen.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/screens/settings/DataManagementScreen.kt
@@ -300,8 +300,9 @@ private fun showRasterUrlDialog(context: Context, prefs: SharedPreferences) {
         doAfterTextChanged {
             val t = it.toString()
             d?.getButton(AlertDialog.BUTTON_POSITIVE)?.isEnabled =
-                (t.contains("{x}") && t.contains("{y}") && t.contains("{z}")) ||
-                    t.contains("{bbox-epsg-3857}")
+                (t.contains("{x}") && t.contains("{y}") && (t.contains("{z}") || t.contains("{zoom}")))
+                    || t.contains("{bbox-epsg-3857}")
+                    || (t.contains("{bbox}") && t.contains("{proj}"))
         }
     }
     val hideLabelsSwitch = SwitchCompat(context).apply {

--- a/app/src/androidMain/res/values/strings_ee.xml
+++ b/app/src/androidMain/res/values/strings_ee.xml
@@ -138,7 +138,7 @@
     <string name="tree_custom_quest_import">Provide</string>
     <string name="tree_custom_quest_export">Get</string>
     <string name="pref_tile_source_title">Tile source for satellite / aerial images</string>
-    <string name="pref_tile_source_message">Tile URL must contain {x}, {y} and {z}</string>
+    <string name="pref_tile_source_message">Tile URL must contain {x}, {y} and {z} or {bbox-epsg-3857}</string>
     <string name="pref_tile_source_hide_labels">Hide labels</string>
     <string name="pref_tile_maxzoom">Max supported zoom</string>
     <string name="pref_tree_custom_quest_summary">See message when enabling quest for details</string>

--- a/app/src/androidMain/res/values/strings_ee.xml
+++ b/app/src/androidMain/res/values/strings_ee.xml
@@ -137,8 +137,8 @@
     <string name="tree_custom_quest_import_export_message">Get currently used file or provide a new one? Check the corresponding quest enable message for details.</string>
     <string name="tree_custom_quest_import">Provide</string>
     <string name="tree_custom_quest_export">Get</string>
-    <string name="pref_tile_source_title">Tile source for satellite / aerial images</string>
-    <string name="pref_tile_source_message">Tile URL must contain {x}, {y} and {z} or {bbox-epsg-3857}</string>
+    <string name="pref_tile_source_title">Source for satellite / aerial images</string>
+    <string name="pref_tile_source_message">Tile source the URL must contain {x}, {y} and either {z} or {zoom}. WMS source needs to support EPSG:3857 and URL must contain either {bbox-epsg-3857} or both {bbox} and {proj}.</string>
     <string name="pref_tile_source_hide_labels">Hide labels</string>
     <string name="pref_tile_maxzoom">Max supported zoom</string>
     <string name="pref_tree_custom_quest_summary">See message when enabling quest for details</string>

--- a/app/src/commonMain/composeResources/values/strings_ee.xml
+++ b/app/src/commonMain/composeResources/values/strings_ee.xml
@@ -138,7 +138,7 @@
     <string name="tree_custom_quest_import">Provide</string>
     <string name="tree_custom_quest_export">Get</string>
     <string name="pref_tile_source_title">Tile source for satellite / aerial images</string>
-    <string name="pref_tile_source_message">Tile URL must contain {x}, {y} and {z}</string>
+    <string name="pref_tile_source_message">Tile URL must contain {x}, {y} and {z} or {bbox-epsg-3857}</string>
     <string name="pref_tile_source_hide_labels">Hide labels</string>
     <string name="pref_tile_maxzoom">Max supported zoom</string>
     <string name="pref_tree_custom_quest_summary">See message when enabling quest for details</string>


### PR DESCRIPTION
Inspired by #525 - not really fixing it, but improving the situation to use also bbox-epsg-3857 WMS beside XYZ-tiles only.

See comment with instructions to test / use: https://github.com/Helium314/SCEE/issues/525#issuecomment-3929673751