### PR TITLE
Add highway=bus_stop to favorites

### DIFF
--- a/app/src/androidMain/kotlin/de/westnordost/streetcomplete/view/dialogs/SearchFeaturesDialog.kt
+++ b/app/src/androidMain/kotlin/de/westnordost/streetcomplete/view/dialogs/SearchFeaturesDialog.kt
@@ -227,4 +227,5 @@ private val iconOnlyFeatures = mapOf(
     "entrance" to R.drawable.quest_door,
     "highway/stop" to R.drawable.preset_temaki_stop,
     "highway/give_way" to R.drawable.preset_temaki_yield,
+    "highway/bus_stop" to R.drawable.preset_temaki_bus,
 )

--- a/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/Things.kt
+++ b/app/src/commonMain/kotlin/de/westnordost/streetcomplete/osm/Things.kt
@@ -322,6 +322,7 @@ private val IS_SCEE_THING_EXPRESSION by lazy {
 val POPULAR_THING_FEATURE_IDS = listOf(
     "natural/tree/broadleaved",    // 4.8 M
     "highway/street_lamp",         // 4.3 M
+    "highway/bus_stop",            // 4.0 M
     "amenity/bench",               // 2.6 M
     "emergency/fire_hydrant",      // 2.1 M
     "amenity/waste_basket",        // 0.9 M


### PR DESCRIPTION
They are quite popular [(4M)](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dbus_stop) and often missing from the OSM, so should be easy to add

tested [here](https://github.com/mnalis/StreetComplete/actions/runs/22801226477):

![small_Screenshot_20260308_004057_SCEE Dev](https://github.com/user-attachments/assets/3b794be1-5a63-4b72-b5d5-e476ea9dd30c)
